### PR TITLE
Add MDX content layer and search endpoint

### DIFF
--- a/scripts/ingest.ts
+++ b/scripts/ingest.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { getAllDocuments } from "../src/lib/content";
+
+interface IngestChunk {
+  slug: string;
+  title: string;
+  heading: string | null;
+  content: string;
+}
+
+function splitIntoChunks(body: string): IngestChunk[] {
+  const lines = body.split(/\r?\n/);
+  const chunks: IngestChunk[] = [];
+  let currentHeading: string | null = null;
+  let buffer: string[] = [];
+
+  const pushChunk = () => {
+    if (buffer.length === 0) {
+      return;
+    }
+
+    const content = buffer.join(" ").replace(/\s+/g, " ").trim();
+    if (content) {
+      chunks.push({
+        slug: "",
+        title: "",
+        heading: currentHeading,
+        content,
+      });
+    }
+
+    buffer = [];
+  };
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      pushChunk();
+      currentHeading = headingMatch[2].trim();
+      continue;
+    }
+
+    buffer.push(line.trim());
+  }
+
+  pushChunk();
+
+  return chunks;
+}
+
+async function main() {
+  const documents = await getAllDocuments();
+  const chunks: IngestChunk[] = [];
+
+  for (const document of documents) {
+    const documentChunks = splitIntoChunks(document.body).map((chunk) => ({
+      ...chunk,
+      slug: document.slug,
+      title: document.frontmatter.title,
+    }));
+
+    if (documentChunks.length === 0) {
+      chunks.push({
+        slug: document.slug,
+        title: document.frontmatter.title,
+        heading: null,
+        content: document.body.replace(/\s+/g, " ").trim(),
+      });
+    } else {
+      chunks.push(...documentChunks);
+    }
+  }
+
+  const outputDirectory = path.join(process.cwd(), ".cache", "ingest");
+  const outputFile = path.join(outputDirectory, "content.json");
+
+  await fs.mkdir(outputDirectory, { recursive: true });
+  await fs.writeFile(outputFile, JSON.stringify(chunks, null, 2), "utf8");
+
+  console.log(`Wrote ${chunks.length} content chunks to ${path.relative(process.cwd(), outputFile)}`);
+}
+
+main().catch((error) => {
+  console.error("Failed to ingest content", error);
+  process.exit(1);
+});

--- a/src/app/api/content/search/route.ts
+++ b/src/app/api/content/search/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+
+import { createSnippet, getAllDocuments } from "../../../../lib/content";
+
+interface SearchResult {
+  slug: string;
+  title: string;
+  snippet: string;
+  score: number;
+}
+
+function scoreDocument(text: string, query: string): number {
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter(Boolean);
+
+  if (terms.length === 0) {
+    return 0;
+  }
+
+  const haystack = text.toLowerCase();
+  let score = 0;
+
+  for (const term of terms) {
+    if (!term) {
+      continue;
+    }
+
+    let index = haystack.indexOf(term);
+    while (index !== -1) {
+      score += term.length;
+      index = haystack.indexOf(term, index + term.length);
+    }
+  }
+
+  return score;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get("query")?.trim() ?? "";
+
+  if (!query) {
+    return NextResponse.json({ query: "", results: [] });
+  }
+
+  const documents = await getAllDocuments();
+  const scoredResults: SearchResult[] = documents
+    .map((document) => {
+      const fullText = `${document.frontmatter.title}\n${document.body}`;
+      const score = scoreDocument(fullText, query);
+      return {
+        slug: document.slug,
+        title: document.frontmatter.title,
+        snippet: createSnippet(document.body, query),
+        score,
+      } satisfies SearchResult;
+    })
+    .filter((result) => result.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 10);
+
+  return NextResponse.json({
+    query,
+    results: scoredResults.map(({ score, ...rest }) => rest),
+  });
+}

--- a/src/app/documents/[slug]/page.tsx
+++ b/src/app/documents/[slug]/page.tsx
@@ -1,0 +1,53 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { MDXRemote } from "next-mdx-remote/rsc";
+
+import { getAllDocuments, getDocumentBySlug } from "../../../lib/content";
+
+interface DocumentPageProps {
+  params: {
+    slug: string;
+  };
+}
+
+export async function generateStaticParams() {
+  const documents = await getAllDocuments();
+  return documents.map((document) => ({ slug: document.slug }));
+}
+
+export async function generateMetadata({ params }: DocumentPageProps): Promise<Metadata> {
+  const document = await getDocumentBySlug(params.slug);
+
+  if (!document) {
+    return { title: "Document Not Found" };
+  }
+
+  return {
+    title: `${document.frontmatter.title} | TCSLC`,
+    description: document.frontmatter.description ?? undefined,
+  };
+}
+
+export default async function DocumentPage({ params }: DocumentPageProps) {
+  const document = await getDocumentBySlug(params.slug);
+
+  if (!document) {
+    notFound();
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl px-6 py-12">
+      <header className="mb-10">
+        <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+          Resource
+        </p>
+        <h1 className="text-4xl font-semibold tracking-tight text-foreground">
+          {document.frontmatter.title}
+        </h1>
+      </header>
+      <article className="prose prose-slate dark:prose-invert">
+        <MDXRemote source={document.body} />
+      </article>
+    </div>
+  );
+}

--- a/src/content/about.mdx
+++ b/src/content/about.mdx
@@ -1,0 +1,8 @@
+---
+title: "About"
+slug: "about"
+---
+
+# About the Office
+
+This is placeholder content for the About page. Real copy will be imported later.

--- a/src/content/faqs.mdx
+++ b/src/content/faqs.mdx
@@ -1,0 +1,22 @@
+---
+title: "FAQs"
+slug: "faqs"
+---
+
+# Frequently Asked Questions
+
+## How long will my case take?
+
+Processing times vary by case type, agency workload, and the completeness of documentation. During intake we set expectations and share official processing time resources.
+
+## What documents should I bring to my consultation?
+
+Bring government-issued identification, immigration records, notices from USCIS or the Department of State, and any court documents. A detailed checklist will accompany the final content import.
+
+## Do you offer virtual meetings?
+
+Yes. We support secure video consultations and remote document collaboration to keep cases moving without requiring in-person visits.
+
+## How do professional fees work?
+
+We quote fixed or milestone-based fees for most matters, outlining what is included and when payments are due.

--- a/src/content/fees.mdx
+++ b/src/content/fees.mdx
@@ -1,0 +1,20 @@
+---
+title: "Fees"
+slug: "fees"
+---
+
+# Professional Fees
+
+Our office provides transparent pricing so clients understand the total investment before a case begins. Detailed fee schedules will be populated when the official content migration is complete.
+
+## Flat Fees
+
+We rely on flat-fee structures for most family-based petitions and naturalization matters to simplify budgeting.
+
+## Payment Plans
+
+Flexible payment plans allow clients to pay in installments tied to key case milestones.
+
+## Additional Costs
+
+Government filing fees, translation services, and medical exams are billed separately and are subject to change by third-party providers.

--- a/src/content/required-documents.mdx
+++ b/src/content/required-documents.mdx
@@ -1,0 +1,24 @@
+---
+title: "Required Documents"
+slug: "required-documents"
+---
+
+# Required Documents
+
+Each case type requires specific supporting evidence. The final content will include document checklists tailored to common scenarios.
+
+## Identity
+
+Bring passports, birth certificates, and government-issued identification for every family member involved in the case.
+
+## Status History
+
+Collect prior visas, I-94 records, approval notices, and any correspondence with immigration agencies.
+
+## Relationship Evidence
+
+Gather marriage certificates, adoption decrees, financial support records, and photos that demonstrate qualifying relationships.
+
+## Additional Evidence
+
+Employment letters, academic transcripts, medical records, and police clearances may be required depending on the requested benefit.

--- a/src/content/services.mdx
+++ b/src/content/services.mdx
@@ -1,0 +1,24 @@
+---
+title: "Services"
+slug: "services"
+---
+
+# Legal Services Overview
+
+We help families navigate complex immigration processes with clarity, compassion, and precision. The sections below outline each major service area that will be expanded with official copy during the full content import.
+
+## Family-Based Petitions
+
+We guide clients through petitions for spouses, children, parents, and siblings, including consular processing and adjustment of status strategies.
+
+## Humanitarian Relief
+
+Our office prepares applications for humanitarian programs such as asylum, VAWA, U visas, and parole-in-place, coordinating supporting evidence and timelines.
+
+## Naturalization & Citizenship
+
+From eligibility assessments to interview preparation, we support lawful permanent residents seeking to become United States citizens.
+
+## Business & Employment
+
+We advise employers and employees on temporary worker visas, permanent labor certifications, and related compliance milestones.

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface ContentFrontmatter {
+  title: string;
+  slug: string;
+  [key: string]: string;
+}
+
+export interface ContentDocument {
+  slug: string;
+  body: string;
+  frontmatter: ContentFrontmatter;
+  filepath: string;
+}
+
+const CONTENT_DIRECTORY = path.join(process.cwd(), "src", "content");
+const SUPPORTED_EXTENSIONS = [".mdx", ".md"];
+
+interface ParsedFrontmatter {
+  data: Record<string, string>;
+  body: string;
+}
+
+function parseFrontmatter(raw: string): ParsedFrontmatter {
+  const normalized = raw.startsWith("\ufeff") ? raw.slice(1) : raw;
+  const frontmatterMatch = normalized.match(/^---\n([\s\S]*?)\n---\n?/);
+
+  if (!frontmatterMatch) {
+    return { data: {}, body: normalized.trim() };
+  }
+
+  const frontmatterBlock = frontmatterMatch[1];
+  const body = normalized.slice(frontmatterMatch[0].length).trim();
+  const data: Record<string, string> = {};
+
+  for (const line of frontmatterBlock.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const [rawKey, ...rawValueParts] = trimmed.split(":");
+    const key = rawKey.trim();
+    const rawValue = rawValueParts.join(":").trim();
+    const unquotedValue = rawValue.replace(/^"/, "").replace(/"$/, "");
+
+    if (key) {
+      data[key] = unquotedValue;
+    }
+  }
+
+  return { data, body };
+}
+
+async function readDocumentFile(filepath: string): Promise<ContentDocument | null> {
+  const fileContents = await fs.readFile(filepath, "utf8");
+  const parsed = parseFrontmatter(fileContents);
+  const { data, body } = parsed;
+  const slug = (data.slug || path.parse(filepath).name).trim();
+  const title = (data.title || slug).trim();
+
+  if (!slug) {
+    return null;
+  }
+
+  const frontmatter: ContentFrontmatter = {
+    title,
+    slug,
+    ...data,
+  };
+
+  return {
+    slug,
+    body,
+    frontmatter,
+    filepath,
+  };
+}
+
+async function listContentFiles(): Promise<string[]> {
+  const files = await fs.readdir(CONTENT_DIRECTORY);
+  return files
+    .filter((file) => SUPPORTED_EXTENSIONS.includes(path.extname(file).toLowerCase()))
+    .map((file) => path.join(CONTENT_DIRECTORY, file));
+}
+
+export async function getAllDocuments(): Promise<ContentDocument[]> {
+  const files = await listContentFiles();
+  const documents: ContentDocument[] = [];
+
+  for (const filepath of files) {
+    const document = await readDocumentFile(filepath);
+    if (document) {
+      documents.push(document);
+    }
+  }
+
+  return documents.sort((a, b) => a.frontmatter.title.localeCompare(b.frontmatter.title));
+}
+
+export async function getDocumentBySlug(slug: string): Promise<ContentDocument | null> {
+  const normalizedSlug = slug.trim().toLowerCase();
+
+  for (const extension of SUPPORTED_EXTENSIONS) {
+    const targetPath = path.join(CONTENT_DIRECTORY, `${normalizedSlug}${extension}`);
+
+    try {
+      const document = await readDocumentFile(targetPath);
+      if (document) {
+        return document;
+      }
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  const documents = await getAllDocuments();
+  return (
+    documents.find((document) => document.slug.toLowerCase() === normalizedSlug) ?? null
+  );
+}
+
+export function createSnippet(text: string, query: string, length = 200): string {
+  const normalizedText = text.replace(/\s+/g, " ").trim();
+  if (!normalizedText) {
+    return "";
+  }
+
+  const normalizedQuery = query.toLowerCase();
+  const lowerText = normalizedText.toLowerCase();
+  const index = lowerText.indexOf(normalizedQuery);
+
+  if (index === -1) {
+    return normalizedText.length > length
+      ? `${normalizedText.slice(0, length).trimEnd()}…`
+      : normalizedText;
+  }
+
+  const half = Math.floor((length - normalizedQuery.length) / 2);
+  const start = Math.max(0, index - half);
+  const end = Math.min(normalizedText.length, index + normalizedQuery.length + half);
+
+  let snippet = normalizedText.slice(start, end).trim();
+  if (start > 0) {
+    snippet = `…${snippet}`;
+  }
+  if (end < normalizedText.length) {
+    snippet = `${snippet}…`;
+  }
+
+  return snippet;
+}


### PR DESCRIPTION
## Summary
- add initial MDX content placeholders for about, services, FAQs, fees, and required documents
- introduce a filesystem-backed content loader with snippet helper and document page rendering
- provide a search API endpoint and ingestion script for RAG-ready content chunks

## Testing
- not run (project setup not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68d6a4b6f0bc8321b6fc819ec1c8e830