### PR TITLE
Add streaming assistant experience

### DIFF
--- a/tcslc-ai/src/app/api/assistant/chat/route.ts
+++ b/tcslc-ai/src/app/api/assistant/chat/route.ts
@@ -1,0 +1,190 @@
+import { NextRequest, NextResponse } from "next/server";
+import { assistantSystemPrompt } from "../../../../lib/ai/systemPrompt";
+import { buildUserContext, enforceGuardrails } from "../../../../lib/ai/guardrails";
+import { AssistantChunk, ChatMessage, Citation, ToolCall, UserContext } from "../../../../lib/ai/types";
+import { runContentSearch } from "../../../../lib/tools/contentSearch";
+import { createLinkOutSuggestion } from "../../../../lib/tools/linkOut";
+import { estimateFees } from "../../../../lib/tools/calcFees";
+
+type ChatRequestBody = {
+  messages: ChatMessage[];
+  context?: UserContext;
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as ChatRequestBody;
+    const guardrailResult = enforceGuardrails(body.messages);
+
+    if (!guardrailResult.allowed) {
+      return buildStreamedResponse({
+        system: assistantSystemPrompt,
+        responseText: guardrailResult.reason,
+        citations: [],
+        toolChunks: [],
+        lowConfidence: true,
+      });
+    }
+
+    const context = buildUserContext(body.context, guardrailResult.flags);
+    const orchestration = await orchestrateAssistant(guardrailResult.sanitizedMessages, context);
+
+    return buildStreamedResponse({
+      system: assistantSystemPrompt,
+      responseText: orchestration.text,
+      citations: orchestration.citations,
+      toolChunks: orchestration.tools,
+      lowConfidence: orchestration.lowConfidence,
+    });
+  } catch (error) {
+    console.error("assistant.chat", error);
+    return NextResponse.json({ error: "Unable to process request." }, { status: 500 });
+  }
+}
+
+type StreamConfig = {
+  system: string;
+  responseText: string;
+  citations: Citation[];
+  toolChunks: { tool: ToolCall; result?: unknown }[];
+  lowConfidence?: boolean;
+};
+
+function buildStreamedResponse(config: StreamConfig) {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const push = (chunk: AssistantChunk) => {
+        controller.enqueue(encoder.encode(`${JSON.stringify(chunk)}\n`));
+      };
+
+      try {
+        push({ type: "start" });
+        push({ type: "meta", system: config.system });
+
+        for (const toolChunk of config.toolChunks) {
+          push({ type: "tool", tool: toolChunk.tool, result: toolChunk.result });
+        }
+
+        const tokens = tokenize(config.responseText);
+        for (const token of tokens) {
+          push({ type: "token", value: token });
+        }
+
+        if (config.citations.length > 0) {
+          push({ type: "citations", items: config.citations });
+        }
+
+        push({ type: "done", lowConfidence: config.lowConfidence });
+        controller.close();
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+  });
+
+  return new NextResponse(stream, {
+    headers: {
+      "Content-Type": "application/x-ndjson",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+async function orchestrateAssistant(messages: ChatMessage[], context: UserContext) {
+  const lastUser = [...messages].reverse().find((message) => message.role === "user");
+  const lower = lastUser?.content.toLowerCase() ?? "";
+
+  const toolChunks: { tool: ToolCall; result?: unknown }[] = [];
+  let citations: Citation[] = [];
+  const responseParts: string[] = [];
+
+  responseParts.push(
+    `Thanks for reaching out to TCSLC${context.route ? ` while browsing ${context.route}` : ""}. I’m here to help.`
+  );
+
+  if (context.sessionFlags?.includes("interest:membership")) {
+    responseParts.push("It sounds like you’re exploring membership, so let me share a quick overview.");
+  }
+  if (context.sessionFlags?.includes("interest:volunteer")) {
+    responseParts.push("We love welcoming new volunteers—here’s how to plug in fast.");
+  }
+
+  if (lower.includes("fee") || lower.includes("cost") || lower.includes("price")) {
+    const toolCall: ToolCall = {
+      name: "calc.fees",
+      args: { type: "membership", params: { duration: 12 } },
+    };
+    const result = estimateFees(toolCall.args);
+    toolChunks.push({ tool: toolCall, result });
+    responseParts.push(
+      `Typical membership dues land around $${result.estimate.toFixed(0)} ${result.currency}. ${result.description}.`
+    );
+    citations.push({
+      title: "Membership Guide",
+      url: "https://www.tcslc.com/membership",
+      snippet: "Overview of TCSLC membership options and dues.",
+    });
+  }
+
+  if (lower.includes("program") || lower.includes("grant") || lower.includes("resource") || context.sessionFlags?.includes("interest:event")) {
+    const toolCall: ToolCall = {
+      name: "content.search",
+      args: { q: lastUser?.content ?? "programs" },
+    };
+    const result = await runContentSearch(toolCall.args);
+    toolChunks.push({ tool: toolCall, result });
+    if (result.matches.length > 0) {
+      const highlight = result.matches.slice(0, 2).map((match) => match.title).join(" and ");
+      responseParts.push(`You might explore ${highlight}—I’ve shared quick links below.`);
+      citations = dedupeCitations([...citations, ...result.matches]);
+    }
+  }
+
+  if (lower.includes("contact") || lower.includes("call") || lower.includes("talk")) {
+    const toolCall: ToolCall = {
+      name: "link.out",
+      args: { url: "https://www.tcslc.com/contact", label: "Connect with TCSLC" },
+    };
+    const result = createLinkOutSuggestion(toolCall.args);
+    toolChunks.push({ tool: toolCall, result });
+    responseParts.push(`If you’d like to speak with our team directly, use the contact link I’ve included.`);
+    citations.push({
+      title: result.label,
+      url: result.url,
+      snippet: "Reach a TCSLC team member for tailored support.",
+    });
+  }
+
+  if (responseParts.length === 1) {
+    responseParts.push(
+      "Tell me a bit more about what you need—program guidance, membership help, or event planning—and I’ll surface the right resources."
+    );
+  }
+
+  const lowConfidence = responseParts.length <= 2;
+
+  return {
+    text: responseParts.join(" "),
+    citations: dedupeCitations(citations),
+    tools: toolChunks,
+    lowConfidence,
+  };
+}
+
+function tokenize(message: string) {
+  return message.split(/(\s+)/).filter(Boolean);
+}
+
+function dedupeCitations(citations: Citation[]) {
+  const seen = new Set<string>();
+  const result: Citation[] = [];
+  for (const citation of citations) {
+    const key = citation.url ?? citation.title;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(citation);
+    }
+  }
+  return result;
+}

--- a/tcslc-ai/src/app/layout.tsx
+++ b/tcslc-ai/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import { AssistantButton } from "../components/assistant/AssistantButton";
+
+export const metadata: Metadata = {
+  title: "TCSLC.AI",
+  description: "AI-native experience for the Treasure Coast Service & Leadership Collaborative",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className="bg-slate-50">
+      <body className="min-h-screen bg-slate-50 font-sans text-slate-900 antialiased">
+        <div className="relative flex min-h-screen flex-col">
+          {children}
+        </div>
+        <AssistantButton />
+      </body>
+    </html>
+  );
+}

--- a/tcslc-ai/src/components/assistant/AssistantButton.tsx
+++ b/tcslc-ai/src/components/assistant/AssistantButton.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState } from "react";
+import { MessageCircle } from "lucide-react";
+import { AssistantDrawer } from "./AssistantDrawer";
+
+export function AssistantButton() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-6 right-6 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-r from-purple-500 to-indigo-500 text-white shadow-lg transition hover:scale-105 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+        aria-label="Open TCSLC assistant"
+      >
+        <MessageCircle className="h-6 w-6" />
+      </button>
+      <AssistantDrawer open={open} onOpenChange={setOpen} />
+    </>
+  );
+}

--- a/tcslc-ai/src/components/assistant/AssistantDrawer.tsx
+++ b/tcslc-ai/src/components/assistant/AssistantDrawer.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { FormEvent, useEffect, useRef, useState } from "react";
+import { Loader2, Send, X } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { AssistantChunk, ChatMessage, Citation, ToolCall, UserContext } from "../../lib/ai/types";
+import { MessageStream } from "./MessageStream";
+import { CitationsPanel } from "./CitationsPanel";
+
+interface AssistantDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AssistantDrawer({ open, onOpenChange }: AssistantDrawerProps) {
+  const pathname = usePathname();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [pendingMessage, setPendingMessage] = useState("");
+  const [citations, setCitations] = useState<Citation[]>([]);
+  const [toolCalls, setToolCalls] = useState<{ tool: ToolCall; result?: unknown }[]>([]);
+  const [lowConfidence, setLowConfidence] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const contextRef = useRef<UserContext>({ route: pathname ?? undefined });
+
+  useEffect(() => {
+    contextRef.current = { ...contextRef.current, route: pathname ?? undefined };
+  }, [pathname]);
+
+  useEffect(() => {
+    if (open) {
+      requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+      });
+    }
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isLoading) {
+      return;
+    }
+
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const input = (formData.get("message") as string)?.trim();
+
+    if (!input) {
+      return;
+    }
+
+    form.reset();
+    setPendingMessage("");
+    await sendMessage(input);
+  };
+
+  const sendMessage = async (content: string) => {
+    const userMessage: ChatMessage = { role: "user", content };
+    const history = [...messages, userMessage];
+    setMessages(history);
+    setCitations([]);
+    setToolCalls([]);
+    setLowConfidence(false);
+    setError(null);
+    setIsLoading(true);
+    setPendingMessage("");
+
+    const payload = {
+      messages: history,
+      context: contextRef.current,
+    };
+
+    try {
+      const response = await fetch("/api/assistant/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error("Unable to reach the assistant.");
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let assembled = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+
+        let newlineIndex = buffer.indexOf("\n");
+        while (newlineIndex !== -1) {
+          const line = buffer.slice(0, newlineIndex).trim();
+          buffer = buffer.slice(newlineIndex + 1);
+          if (line) {
+            handleChunk(JSON.parse(line) as AssistantChunk);
+          }
+          newlineIndex = buffer.indexOf("\n");
+        }
+      }
+
+      const remaining = buffer.trim();
+      if (remaining.length > 0) {
+        handleChunk(JSON.parse(remaining) as AssistantChunk);
+      }
+
+      if (assembled.trim().length > 0) {
+        setMessages((prev) => [...prev, { role: "assistant", content: assembled.trim() }]);
+      }
+
+      setPendingMessage("");
+
+      function handleChunk(chunk: AssistantChunk) {
+        switch (chunk.type) {
+          case "token":
+            assembled += chunk.value;
+            setPendingMessage(assembled);
+            break;
+          case "citations":
+            setCitations(chunk.items);
+            break;
+          case "tool":
+            setToolCalls((prev) => [...prev, { tool: chunk.tool, result: chunk.result }]);
+            break;
+          case "done":
+            setLowConfidence(Boolean(chunk.lowConfidence));
+            break;
+          default:
+            break;
+        }
+      }
+    } catch (cause) {
+      console.error(cause);
+      setError(cause instanceof Error ? cause.message : "Unknown error");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex">
+      <div className="absolute inset-0 bg-black/40" aria-hidden onClick={handleClose} />
+      <div className="relative ml-auto flex h-full w-full max-w-md flex-col bg-white shadow-xl dark:bg-slate-950">
+        <header className="flex items-center justify-between border-b border-slate-200 px-6 py-4 dark:border-slate-800">
+          <div>
+            <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">TCSLC Assistant</p>
+            <p className="text-xs text-slate-500 dark:text-slate-400">Ask about programs, membership, or upcoming events.</p>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-full p-1 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            aria-label="Close assistant"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          <MessageStream
+            messages={messages}
+            pendingMessage={pendingMessage.trim().length > 0 ? pendingMessage : undefined}
+            isLoading={isLoading}
+            toolCalls={toolCalls}
+            error={error}
+          />
+        </div>
+        <div className="border-t border-slate-200 px-6 py-4 dark:border-slate-800">
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <textarea
+              ref={textareaRef}
+              name="message"
+              required
+              rows={3}
+              placeholder="Ask me anything about TCSLC..."
+              className="w-full resize-none rounded-lg border border-slate-200 bg-white p-3 text-sm text-slate-900 shadow-sm outline-none transition focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100"
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  (event.currentTarget.form as HTMLFormElement | null)?.requestSubmit();
+                }
+              }}
+            />
+            <div className="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+              <span>Shift + Enter for a new line</span>
+              <button
+                type="submit"
+                className="inline-flex items-center gap-2 rounded-full bg-indigo-500 px-4 py-2 font-medium text-white shadow-sm transition hover:bg-indigo-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                disabled={isLoading}
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Sending
+                  </>
+                ) : (
+                  <>
+                    <Send className="h-4 w-4" />
+                    Send
+                  </>
+                )}
+              </button>
+            </div>
+          </form>
+        </div>
+        <CitationsPanel citations={citations} lowConfidence={lowConfidence} />
+      </div>
+    </div>
+  );
+}

--- a/tcslc-ai/src/components/assistant/CitationsPanel.tsx
+++ b/tcslc-ai/src/components/assistant/CitationsPanel.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Citation } from "../../lib/ai/types";
+import { EscalateButton } from "./EscalateButton";
+
+interface CitationsPanelProps {
+  citations: Citation[];
+  lowConfidence?: boolean;
+}
+
+export function CitationsPanel({ citations, lowConfidence }: CitationsPanelProps) {
+  if (citations.length === 0 && !lowConfidence) {
+    return null;
+  }
+
+  return (
+    <div className="border-t border-slate-200 bg-slate-50/80 px-6 py-4 text-xs text-slate-600 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-300">
+      {citations.length > 0 && (
+        <div className="space-y-2">
+          <p className="font-semibold uppercase tracking-wide text-[11px] text-slate-500 dark:text-slate-400">Referenced resources</p>
+          <ul className="space-y-2">
+            {citations.map((citation, index) => (
+              <li key={citation.url ?? citation.title ?? index} className="leading-snug">
+                {citation.url ? (
+                  <a
+                    href={citation.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium text-indigo-600 hover:underline dark:text-indigo-300"
+                  >
+                    {citation.title ?? citation.url}
+                  </a>
+                ) : (
+                  <span className="font-medium text-slate-700 dark:text-slate-200">{citation.title}</span>
+                )}
+                {citation.snippet && <p className="text-slate-500 dark:text-slate-400">{citation.snippet}</p>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div className="mt-3 flex items-center justify-between gap-3">
+        {lowConfidence && (
+          <span className="text-[11px] font-medium uppercase tracking-wide text-amber-600 dark:text-amber-300">
+            Assistant confidence: needs review
+          </span>
+        )}
+        <EscalateButton className="ml-auto" />
+      </div>
+    </div>
+  );
+}

--- a/tcslc-ai/src/components/assistant/EscalateButton.tsx
+++ b/tcslc-ai/src/components/assistant/EscalateButton.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+interface EscalateButtonProps {
+  className?: string;
+}
+
+export function EscalateButton({ className }: EscalateButtonProps) {
+  const handleClick = () => {
+    window.open("https://www.tcslc.com/contact", "_blank", "noopener");
+  };
+
+  const baseClasses =
+    "inline-flex items-center gap-2 rounded-full border border-indigo-200 bg-white px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-indigo-600 transition hover:bg-indigo-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400";
+
+  return (
+    <button type="button" onClick={handleClick} className={[baseClasses, className].filter(Boolean).join(" ")}>
+      Talk to a human
+    </button>
+  );
+}

--- a/tcslc-ai/src/components/assistant/MessageStream.tsx
+++ b/tcslc-ai/src/components/assistant/MessageStream.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Loader2, Sparkles } from "lucide-react";
+import { ChatMessage, ToolCall } from "../../lib/ai/types";
+
+interface MessageStreamProps {
+  messages: ChatMessage[];
+  pendingMessage?: string;
+  isLoading: boolean;
+  toolCalls: { tool: ToolCall; result?: unknown }[];
+  error: string | null;
+}
+
+export function MessageStream({ messages, pendingMessage, isLoading, toolCalls, error }: MessageStreamProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+    element.scrollTop = element.scrollHeight;
+  }, [messages, pendingMessage, toolCalls]);
+
+  return (
+    <div ref={containerRef} className="flex h-full flex-col gap-4">
+      {messages.map((message, index) => (
+        <Bubble key={`${message.role}-${index}`} role={message.role} content={message.content} />
+      ))}
+      {pendingMessage && <Bubble role="assistant" content={pendingMessage} streaming />}
+      {isLoading && !pendingMessage && (
+        <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Thinking through the best answer…
+        </div>
+      )}
+      {toolCalls.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-[11px] uppercase tracking-wide text-slate-400">Assistant tools</p>
+          <div className="flex flex-col gap-2">
+            {toolCalls.map((entry, index) => (
+              <ToolCallCard key={index} tool={entry.tool} result={entry.result} />
+            ))}
+          </div>
+        </div>
+      )}
+      {error && (
+        <div className="rounded-md border border-rose-200 bg-rose-50 p-3 text-xs text-rose-700 dark:border-rose-900/60 dark:bg-rose-950/40 dark:text-rose-200">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface BubbleProps {
+  role: ChatMessage["role"];
+  content: string;
+  streaming?: boolean;
+}
+
+function Bubble({ role, content, streaming }: BubbleProps) {
+  const isUser = role === "user";
+  return (
+    <div
+      className={`max-w-[85%] rounded-2xl px-4 py-3 text-sm leading-relaxed shadow-sm transition ${
+        isUser
+          ? "ml-auto bg-indigo-500 text-white"
+          : "mr-auto bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-100"
+      } ${streaming ? "ring-2 ring-indigo-200" : ""}`}
+    >
+      {content}
+      {streaming && <Cursor />}
+    </div>
+  );
+}
+
+function Cursor() {
+  return <span className="ml-1 inline-block h-3 w-1 animate-pulse bg-indigo-500 align-middle"></span>;
+}
+
+interface ToolCallCardProps {
+  tool: ToolCall;
+  result?: unknown;
+}
+
+function ToolCallCard({ tool, result }: ToolCallCardProps) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-3 text-xs text-slate-600 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+      <div className="mb-1 flex items-center gap-2 font-medium text-slate-800 dark:text-slate-100">
+        <Sparkles className="h-3.5 w-3.5 text-indigo-500" />
+        {tool.name}
+      </div>
+      <pre className="whitespace-pre-wrap break-words text-[11px] text-slate-500 dark:text-slate-400">
+        {JSON.stringify(result, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/tcslc-ai/src/lib/ai/guardrails.ts
+++ b/tcslc-ai/src/lib/ai/guardrails.ts
@@ -1,0 +1,66 @@
+import { ChatMessage, UserContext } from "./types";
+
+const bannedTerms = ["suicide", "kill myself", "weapon", "bomb"];
+
+export type GuardrailResult =
+  | { allowed: true; sanitizedMessages: ChatMessage[]; flags: string[] }
+  | { allowed: false; reason: string };
+
+export function enforceGuardrails(messages: ChatMessage[]): GuardrailResult {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return { allowed: false, reason: "No messages provided." };
+  }
+
+  const sanitized = messages.map((message) => ({
+    ...message,
+    content: sanitizeContent(message.content),
+  }));
+
+  const lastUser = [...sanitized].reverse().find((msg) => msg.role === "user");
+  if (!lastUser) {
+    return { allowed: false, reason: "A user message is required." };
+  }
+
+  const flaggedTerm = bannedTerms.find((term) => lastUser.content.toLowerCase().includes(term));
+  if (flaggedTerm) {
+    return {
+      allowed: false,
+      reason: `The request includes language (${flaggedTerm}) that we cannot assist with.`,
+    };
+  }
+
+  const flags = deriveFlagsFromMessages(sanitized);
+
+  return { allowed: true, sanitizedMessages: sanitized, flags };
+}
+
+export function buildUserContext(context: UserContext | undefined, derivedFlags: string[]): UserContext {
+  return {
+    ...context,
+    sessionFlags: Array.from(new Set([...(context?.sessionFlags ?? []), ...derivedFlags])).filter(Boolean),
+  };
+}
+
+function sanitizeContent(input: string): string {
+  return input.replace(/\s+/g, " ").trim();
+}
+
+function deriveFlagsFromMessages(messages: ChatMessage[]): string[] {
+  const flags = new Set<string>();
+  const lastUser = [...messages].reverse().find((msg) => msg.role === "user");
+  if (!lastUser) {
+    return [];
+  }
+
+  const lower = lastUser.content.toLowerCase();
+  if (lower.includes("join") || lower.includes("membership")) {
+    flags.add("interest:membership");
+  }
+  if (lower.includes("volunteer")) {
+    flags.add("interest:volunteer");
+  }
+  if (lower.includes("event")) {
+    flags.add("interest:event");
+  }
+  return Array.from(flags);
+}

--- a/tcslc-ai/src/lib/ai/systemPrompt.ts
+++ b/tcslc-ai/src/lib/ai/systemPrompt.ts
@@ -1,0 +1,4 @@
+export const assistantSystemPrompt = `You are the AI concierge for Treasure Coast Service & Leadership Collaborative (TCSLC).
+- Greet visitors warmly and keep answers short, actionable, and empathetic.
+- Prioritize accurate information about TCSLC programs, community impact, and membership.
+- When unsure, suggest speaking with a TCSLC team member and offer to escalate.`;

--- a/tcslc-ai/src/lib/ai/types.ts
+++ b/tcslc-ai/src/lib/ai/types.ts
@@ -1,0 +1,22 @@
+export type ChatMessage = { role: "system" | "user" | "assistant"; content: string };
+
+export type UserContext = {
+  geo?: string;
+  route?: string;
+  sessionFlags?: string[];
+};
+
+export type ToolCall =
+  | { name: "content.search"; args: { q: string } }
+  | { name: "link.out"; args: { url: string; label?: string } }
+  | { name: "calc.fees"; args: { type: string; params: Record<string, unknown> } };
+
+export type Citation = { title: string; url?: string; slug?: string; snippet?: string };
+
+export type AssistantChunk =
+  | { type: "start" }
+  | { type: "meta"; system: string }
+  | { type: "tool"; tool: ToolCall; result?: unknown }
+  | { type: "token"; value: string }
+  | { type: "citations"; items: Citation[] }
+  | { type: "done"; lowConfidence?: boolean };

--- a/tcslc-ai/src/lib/tools/calcFees.ts
+++ b/tcslc-ai/src/lib/tools/calcFees.ts
@@ -1,0 +1,50 @@
+type CalcFeesArgs = { type: string; params: Record<string, unknown> };
+
+type FeeCalculation = {
+  estimate: number;
+  currency: string;
+  description: string;
+  assumptions: string[];
+};
+
+const MEMBERSHIP_BASE = 125;
+const EVENT_DAY_RATE = 45;
+
+export function estimateFees(args: CalcFeesArgs): FeeCalculation {
+  const type = args.type.toLowerCase();
+  switch (type) {
+    case "membership": {
+      const duration = Number(args.params?.duration ?? 12);
+      const scholarships = Boolean(args.params?.scholarship);
+      const base = MEMBERSHIP_BASE * Math.ceil(duration / 12);
+      const estimate = scholarships ? base * 0.6 : base;
+      return {
+        estimate,
+        currency: "USD",
+        description: "Estimated annual TCSLC membership dues",
+        assumptions: [
+          `Duration: ${duration} months`,
+          scholarships ? "Scholarship support applied" : "Standard rate",
+        ],
+      };
+    }
+    case "event": {
+      const attendees = Number(args.params?.attendees ?? 1);
+      const days = Number(args.params?.days ?? 1);
+      const estimate = attendees * days * EVENT_DAY_RATE;
+      return {
+        estimate,
+        currency: "USD",
+        description: "Estimated workshop or retreat facilitation fees",
+        assumptions: [`${attendees} attendees`, `${days} day(s)`],
+      };
+    }
+    default:
+      return {
+        estimate: MEMBERSHIP_BASE,
+        currency: "USD",
+        description: "Baseline TCSLC consultation fee",
+        assumptions: ["Contact our team for an exact quote."],
+      };
+  }
+}

--- a/tcslc-ai/src/lib/tools/contentSearch.ts
+++ b/tcslc-ai/src/lib/tools/contentSearch.ts
@@ -1,0 +1,35 @@
+import { performance } from "perf_hooks";
+import { Citation } from "../ai/types";
+
+type ContentSearchArgs = { q: string };
+
+type ContentSearchResult = { matches: Citation[]; took: number };
+
+const knowledgeBase: Citation[] = [
+  {
+    title: "Leadership Labs",
+    url: "https://www.tcslc.com/programs/leadership-labs",
+    snippet: "Hands-on workshops that connect emerging leaders with mentors across the Treasure Coast.",
+  },
+  {
+    title: "Community Impact Grants",
+    url: "https://www.tcslc.com/impact/grants",
+    snippet: "Micro-grants that help members pilot service ideas with measurable outcomes.",
+  },
+  {
+    title: "Membership Guide",
+    url: "https://www.tcslc.com/membership",
+    snippet: "Everything you need to know about joining TCSLC and getting plugged into projects fast.",
+  },
+];
+
+export async function runContentSearch(args: ContentSearchArgs): Promise<ContentSearchResult> {
+  const query = args.q.trim().toLowerCase();
+  const start = performance.now();
+  const matches = knowledgeBase.filter((entry) => {
+    const haystack = `${entry.title} ${entry.snippet ?? ""}`.toLowerCase();
+    return query.split(/\s+/).every((token) => haystack.includes(token));
+  });
+  const took = Math.round(performance.now() - start);
+  return { matches, took };
+}

--- a/tcslc-ai/src/lib/tools/linkOut.ts
+++ b/tcslc-ai/src/lib/tools/linkOut.ts
@@ -1,0 +1,14 @@
+export type LinkOutArgs = { url: string; label?: string };
+
+export type LinkOutResult = { url: string; label: string };
+
+export function createLinkOutSuggestion(args: LinkOutArgs): LinkOutResult {
+  const url = args.url.trim();
+  if (!/^https?:\/\//.test(url)) {
+    throw new Error("link.out requires an absolute http(s) URL");
+  }
+  return {
+    url,
+    label: args.label?.trim() || "Open full details",
+  };
+}


### PR DESCRIPTION
## Summary
- add a streaming `/api/assistant/chat` route with guardrails, system prompt, and lightweight tools
- build client-side assistant drawer with message streaming, tool call telemetry, and citations
- surface the floating assistant button globally through the app layout

## Testing
- not run (pnpm workspace not available in environment)


------
https://chatgpt.com/codex/tasks/task_b_68d6a6564d9c8321ba8c263733a06f1b