### PR TITLE
feat: add assistant intent router with quick actions

### DIFF
--- a/src/app/api/assistant/intent/route.ts
+++ b/src/app/api/assistant/intent/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { classifyIntent } from "../../../../lib/intents";
+
+export async function POST(request: Request) {
+  let query = "";
+
+  try {
+    const body = await request.json();
+    if (typeof body?.query === "string") {
+      query = body.query;
+    }
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Invalid JSON body." },
+      { status: 400 }
+    );
+  }
+
+  if (!query.trim()) {
+    return NextResponse.json(
+      { error: "Query text is required." },
+      { status: 400 }
+    );
+  }
+
+  const result = classifyIntent(query);
+
+  return NextResponse.json({
+    query,
+    ...result
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,98 @@
+import { CalendarClock, CarFront, FileSearch, Fish, IdCard, Landmark, Repeat, Store, Wallet } from "lucide-react";
+import { IntentRouter } from "../components/intents/IntentRouter";
+import { QuickActionCard } from "../components/intents/QuickActionCard";
+
+const quickActions = [
+  {
+    title: "Renew Vehicle",
+    description: "Update your vehicle registration or order a new decal.",
+    href: "/services/vehicle-renewal",
+    icon: CarFront
+  },
+  {
+    title: "Pay Property Tax",
+    description: "Submit secure payments for real estate and tangible taxes.",
+    href: "/services/property-tax",
+    icon: Wallet
+  },
+  {
+    title: "Local Business Tax",
+    description: "Register or renew your local business tax receipt online.",
+    href: "/services/business-tax",
+    icon: Store
+  },
+  {
+    title: "Driver License",
+    description: "Schedule a visit or review requirements for identification services.",
+    href: "/services/driver-license",
+    icon: IdCard
+  },
+  {
+    title: "Title Transfer",
+    description: "Transfer ownership, update lienholders, and manage vehicle titles.",
+    href: "/documents/title-transfer",
+    icon: Repeat
+  },
+  {
+    title: "Hunting & Fishing",
+    description: "Purchase or renew hunting, fishing, and sportsman licenses.",
+    href: "/services/outdoor-licensing",
+    icon: Fish
+  },
+  {
+    title: "Tourist Development Tax",
+    description: "File returns for short-term rental and tourist development taxes.",
+    href: "/services/tourist-tax",
+    icon: Landmark
+  },
+  {
+    title: "Book Appointments",
+    description: "Reserve time with our service centers for in-person support.",
+    href: "/contact/appointments",
+    icon: CalendarClock
+  },
+  {
+    title: "Records Search",
+    description: "Access public records, liens, and historical documents online.",
+    href: "/documents/records-search",
+    icon: FileSearch
+  }
+];
+
+export default function HomePage() {
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="relative isolate overflow-hidden">
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.25),_transparent_55%)]" />
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 py-16 md:py-24">
+          <header className="space-y-6 text-center md:text-left">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-widest text-sky-300">
+              AI Native County Experience
+            </span>
+            <h1 className="text-4xl font-semibold leading-tight text-slate-50 sm:text-5xl md:text-6xl">
+              Discover services faster with the Treasure Coast Assistant
+            </h1>
+            <p className="max-w-2xl text-base text-slate-200/80 md:text-lg">
+              Our new AI-powered experience understands everyday language so you can renew registrations, pay taxes, and
+              access records without the guesswork.
+            </p>
+          </header>
+
+          <IntentRouter />
+
+          <section className="space-y-6">
+            <div className="flex items-center justify-between">
+              <h2 className="text-2xl font-semibold text-slate-50">Quick actions</h2>
+              <p className="text-sm text-slate-300/80">Popular tasks handled daily across St. Lucie County.</p>
+            </div>
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {quickActions.map((action) => (
+                <QuickActionCard key={action.title} {...action} />
+              ))}
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/intents/IntentRouter.tsx
+++ b/src/components/intents/IntentRouter.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import type { IntentResult } from "../../lib/intents";
+
+function formatIntentName(intent: IntentResult["intent"]) {
+  if (intent === "unknown") return "Unknown";
+  return intent
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function IntentRouter() {
+  const [query, setQuery] = useState("");
+  const [result, setResult] = useState<IntentResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const formattedConfidence = useMemo(() => {
+    if (!result) return null;
+    return `${Math.round(result.confidence * 100)}%`;
+  }, [result]);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!query.trim()) {
+      setError("Type a question or request to continue.");
+      setResult(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/assistant/intent", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ query })
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload.error ?? "Unable to classify your request.");
+      }
+
+      const payload: IntentResult = await response.json();
+      setResult(payload);
+    } catch (classificationError) {
+      setError(
+        classificationError instanceof Error
+          ? classificationError.message
+          : "Something went wrong. Please try again."
+      );
+      setResult(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-8 shadow-[0_45px_70px_-40px_rgba(15,23,42,0.6)] backdrop-blur">
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold text-slate-50">AI Intent Router</h2>
+          <p className="text-sm text-slate-200/80">
+            Ask a question in plain language and we&apos;ll guide you to the right Treasure Coast Service Center.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row">
+          <label className="sr-only" htmlFor="assistant-query">
+            Ask the assistant
+          </label>
+          <input
+            id="assistant-query"
+            name="query"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Renew my vehicle registration"
+            className="h-12 w-full rounded-full border border-white/10 bg-slate-950/60 px-5 text-sm text-slate-100 placeholder:text-slate-400 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-500/60"
+          />
+          <button
+            type="submit"
+            className="h-12 shrink-0 rounded-full bg-gradient-to-r from-sky-500 via-blue-500 to-indigo-500 px-6 text-sm font-semibold text-white shadow-[0_10px_20px_-15px_rgba(56,189,248,0.9)] transition hover:from-sky-400 hover:via-blue-500 hover:to-indigo-400 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={loading}
+          >
+            {loading ? "Classifying..." : "Find next step"}
+          </button>
+        </form>
+
+        {error && <p className="text-sm text-rose-300">{error}</p>}
+
+        {result && (
+          <div className="rounded-2xl border border-white/10 bg-slate-950/80 p-6">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-slate-400">Predicted intent</p>
+                <p className="text-xl font-semibold text-slate-50">{formatIntentName(result.intent)}</p>
+              </div>
+              {formattedConfidence && (
+                <div className="rounded-full border border-sky-400/30 bg-sky-500/10 px-4 py-1 text-sm font-medium text-sky-200">
+                  Confidence {formattedConfidence}
+                </div>
+              )}
+            </div>
+
+            {result.intent === "unknown" ? (
+              <p className="mt-4 text-sm text-slate-200/80">
+                We couldn&apos;t find an exact match. Explore our service directory for more options.
+              </p>
+            ) : (
+              <p className="mt-4 text-sm text-slate-200/80">
+                Our assistant recommends starting with this service area based on your request.
+              </p>
+            )}
+
+            {result.targetPath && (
+              <Link
+                href={result.targetPath}
+                className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-sky-300 transition hover:text-sky-200"
+              >
+                Visit {result.targetPath}
+                <span aria-hidden="true">→</span>
+              </Link>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/intents/QuickActionCard.tsx
+++ b/src/components/intents/QuickActionCard.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+export type QuickActionCardProps = {
+  title: string;
+  description: string;
+  href: string;
+  icon: LucideIcon;
+};
+
+export function QuickActionCard({ title, description, href, icon: Icon }: QuickActionCardProps) {
+  return (
+    <Link
+      href={href}
+      className="group flex h-full flex-col justify-between rounded-2xl border border-white/10 bg-white/5 p-6 shadow-[0_20px_45px_-20px_rgba(15,23,42,0.35)] backdrop-blur transition hover:-translate-y-1 hover:bg-white/10 hover:shadow-[0_25px_60px_-25px_rgba(15,23,42,0.45)]"
+    >
+      <div className="flex items-center gap-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-slate-900 via-slate-800 to-slate-700 text-white shadow-inner">
+          <Icon className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold text-slate-50">{title}</h3>
+          <p className="text-sm text-slate-200/80">{description}</p>
+        </div>
+      </div>
+      <span className="mt-6 inline-flex items-center text-sm font-medium text-sky-300 transition group-hover:text-sky-200">
+        Explore
+        <ArrowRight className="ml-1 h-4 w-4 transition group-hover:translate-x-1" aria-hidden="true" />
+      </span>
+    </Link>
+  );
+}

--- a/src/lib/intents.ts
+++ b/src/lib/intents.ts
@@ -1,0 +1,70 @@
+export type IntentName =
+  | "renew_vehicle"
+  | "pay_property_tax"
+  | "local_business_tax"
+  | "driver_license"
+  | "title_transfer"
+  | "hunting_fishing"
+  | "tourist_tax"
+  | "appointments"
+  | "records_search";
+
+export type IntentResult = {
+  intent: IntentName | "unknown";
+  slots: Record<string, string>;
+  confidence: number; // 0..1
+  targetPath?: string; // internal next route fallback
+  external?: { url: string; label?: string }; // populated in Prompt 5
+};
+
+const synonyms: Record<IntentName, string[]> = {
+  renew_vehicle: ["renew my tag", "tag renewal", "renew registration", "renew plate", "sticker"],
+  pay_property_tax: ["pay property tax", "property tax payment", "real estate tax"],
+  local_business_tax: ["business tax", "local business tax", "lbt"],
+  driver_license: ["driver license", "license renewal", "dl renewal", "id card"],
+  title_transfer: ["title transfer", "transfer title", "sell my car title"],
+  hunting_fishing: ["hunting license", "fishing license", "sportsman"],
+  tourist_tax: ["tourist tax", "bed tax", "short term rental tax"],
+  appointments: ["appointment", "schedule appointment", "book appointment"],
+  records_search: ["records search", "public records", "lien search"]
+};
+
+const defaults: Partial<Record<IntentName, string>> = {
+  renew_vehicle: "/services",
+  pay_property_tax: "/services",
+  local_business_tax: "/services",
+  driver_license: "/services",
+  title_transfer: "/documents",
+  hunting_fishing: "/services",
+  tourist_tax: "/services",
+  appointments: "/contact",
+  records_search: "/documents"
+};
+
+export function classifyIntent(text: string): IntentResult {
+  const q = text.toLowerCase().trim();
+  let best: { name: IntentName; score: number } | null = null;
+
+  for (const name of Object.keys(synonyms) as IntentName[]) {
+    const terms = synonyms[name];
+    let score = 0;
+    for (const t of terms) {
+      if (q.includes(t)) score = Math.max(score, 1.0);
+    }
+    // fallback keyword heuristics
+    if (name === "renew_vehicle" && /(renew|tag|registration)/.test(q)) score = Math.max(score, 0.7);
+    if (name === "pay_property_tax" && /(property).*(tax)|\btax\b.*property/.test(q)) score = Math.max(score, 0.7);
+    if (name === "driver_license" && /(driver|license|dl|id)/.test(q)) score = Math.max(score, 0.6);
+    if (name === "title_transfer" && /(title).*(transfer)/.test(q)) score = Math.max(score, 0.7);
+    if (name === "appointments" && /(appointment|schedule|book)/.test(q)) score = Math.max(score, 0.6);
+
+    if (!best || score > best.score) best = { name, score };
+  }
+
+  if (!best || best.score < 0.5) {
+    return { intent: "unknown", slots: {}, confidence: best?.score ?? 0, targetPath: "/services" };
+  }
+
+  const targetPath = defaults[best.name] ?? "/services";
+  return { intent: best.name, slots: {}, confidence: Number(best.score.toFixed(2)), targetPath };
+}


### PR DESCRIPTION
## Summary
- implement heuristic-based intent classifier shared utility
- expose intent classification through an assistant API route
- create AI intent router widget and quick action cards on the homepage

## Testing
- pnpm dev *(fails: No package.json found in repo)*

------
https://chatgpt.com/codex/tasks/task_b_68d6a8f1e7c083219abd2df1495ee345