### PR TITLE
Add smart checklists and document helper flows

### DIFF
--- a/src/app/flows/new-business/page.tsx
+++ b/src/app/flows/new-business/page.tsx
@@ -1,0 +1,344 @@
+"use client";
+import { useMemo, useState } from "react";
+
+import { DocumentHelper } from "../../../components/flows/DocumentHelper";
+import { Question } from "../../../components/flows/Question";
+import {
+  ChecklistItem,
+  SmartChecklist,
+} from "../../../components/flows/SmartChecklist";
+import type { FieldHintKey } from "../../../lib/docs/fieldHints";
+
+type BusinessAnswers = {
+  entityType: string;
+  formationState: string;
+  formationDate: string;
+  hasEmployees: string;
+  needsEin: string;
+  dba: string;
+  industry: string;
+  contactEmail: string;
+  contactPhone: string;
+  notes: string;
+};
+
+type BusinessQuestion = {
+  id: keyof BusinessAnswers;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  type?: "text" | "textarea" | "select" | "date" | "email" | "tel";
+  options?: Array<{ value: string; label: string; description?: string }>;
+  className?: string;
+  assistiveText?: string;
+  required?: boolean;
+  disabled?: (answers: BusinessAnswers) => boolean;
+};
+
+const businessQuestions: BusinessQuestion[] = [
+  {
+    id: "entityType",
+    label: "Entity type",
+    description: "We adjust filings and templates based on your business structure.",
+    type: "select",
+    options: [
+      { value: "llc", label: "Limited Liability Company" },
+      { value: "corporation", label: "Corporation" },
+      { value: "partnership", label: "Partnership" },
+      { value: "sole", label: "Sole proprietorship" },
+    ],
+    required: true,
+  },
+  {
+    id: "formationState",
+    label: "State of formation",
+    type: "select",
+    options: [
+      { value: "ca", label: "California" },
+      { value: "nv", label: "Nevada" },
+      { value: "de", label: "Delaware" },
+      { value: "other", label: "Other" },
+    ],
+    required: true,
+  },
+  {
+    id: "formationDate",
+    label: "Formation date",
+    type: "date",
+    required: true,
+  },
+  {
+    id: "hasEmployees",
+    label: "Will you have employees in the first 12 months?",
+    type: "select",
+    options: [
+      { value: "no", label: "No" },
+      { value: "yes", label: "Yes" },
+    ],
+    required: true,
+  },
+  {
+    id: "needsEin",
+    label: "Do you already have an EIN?",
+    type: "select",
+    options: [
+      { value: "have", label: "Yes" },
+      { value: "need", label: "No, I need one" },
+    ],
+    required: true,
+  },
+  {
+    id: "dba",
+    label: "Doing business as (DBA)",
+    placeholder: "Harbor City Logistics",
+    assistiveText: "Leave blank if operating under the legal name only.",
+    className: "md:col-span-2",
+  },
+  {
+    id: "industry",
+    label: "Primary industry",
+    placeholder: "Transportation, SaaS, Retail...",
+    className: "md:col-span-2",
+  },
+  {
+    id: "contactEmail",
+    label: "Contact email",
+    type: "email",
+    placeholder: "founder@company.com",
+    className: "md:col-span-2",
+    required: true,
+  },
+  {
+    id: "contactPhone",
+    label: "Contact phone",
+    type: "tel",
+    placeholder: "(555) 555-0101",
+    className: "md:col-span-2",
+  },
+  {
+    id: "notes",
+    label: "Additional notes",
+    type: "textarea",
+    placeholder: "Licensing deadlines, foreign qualification needs, special ownership structure...",
+    className: "md:col-span-2",
+  },
+];
+
+const articlesDocument = {
+  id: "articles",
+  title: "Articles of Organization/Incorporation",
+  description: "Official state filing showing your legal entity name and filing number.",
+  accept: ["application/pdf", "image/*"],
+  fields: [
+    "businessLegalName",
+    "entityType",
+    "articlesReference",
+    "formationDate",
+    "businessAddress",
+  ] as FieldHintKey[],
+  instructions: [
+    "Make sure the state file stamp and signature are visible.",
+  ],
+};
+
+const einDocument = {
+  id: "ein",
+  title: "IRS EIN confirmation",
+  description: "CP 575 or 147C letter confirming the federal tax ID.",
+  accept: ["application/pdf", "image/*"],
+  fields: ["fein", "businessLegalName", "businessAddress"] as FieldHintKey[],
+  instructions: [
+    "Mask the middle digits before sharing externally to protect sensitive data.",
+  ],
+};
+
+const operatingAgreementDocument = {
+  id: "operating-agreement",
+  title: "Operating agreement / bylaws",
+  description:
+    "Member or shareholder agreement outlining ownership and authority for the new entity.",
+  accept: ["application/pdf", "image/*"],
+  fields: ["operatingAgreement", "ownerLegalName", "contactEmail"] as FieldHintKey[],
+  instructions: [
+    "Upload the signature page and any relevant approval resolutions.",
+  ],
+};
+
+const registeredAgentDocument = {
+  id: "registered-agent",
+  title: "Registered agent authorization",
+  description: "Agent acceptance form or service agreement.",
+  accept: ["application/pdf", "image/*"],
+  fields: ["registeredAgent", "businessAddress"] as FieldHintKey[],
+};
+
+const statementDocument = {
+  id: "statement-information",
+  title: "Initial Statement of Information",
+  description: "Applicable for California corporations and LLCs within 90 days of formation.",
+  accept: ["application/pdf", "image/*"],
+  optional: true,
+  fields: ["businessLegalName", "registeredAgent", "contactEmail", "contactPhone"] as FieldHintKey[],
+};
+
+export default function NewBusinessFlow() {
+  const [answers, setAnswers] = useState<BusinessAnswers>({
+    entityType: "",
+    formationState: "",
+    formationDate: "",
+    hasEmployees: "",
+    needsEin: "",
+    dba: "",
+    industry: "",
+    contactEmail: "",
+    contactPhone: "",
+    notes: "",
+  });
+
+  const checklistItems = useMemo<ChecklistItem[]>(() => {
+    const items: ChecklistItem[] = [
+      { id: "articles", label: "State-approved formation documents", required: true },
+      {
+        id: "owner-id",
+        label: "Owner government-issued ID",
+        required: true,
+      },
+    ];
+
+    if (answers.needsEin === "need" || answers.entityType !== "sole") {
+      items.push({
+        id: "ein",
+        label: "IRS EIN confirmation letter",
+        required: true,
+      });
+    }
+
+    if (answers.entityType === "llc") {
+      items.push({
+        id: "operating-agreement",
+        label: "Executed operating agreement",
+        required: true,
+      });
+    }
+
+    if (answers.entityType === "corporation") {
+      items.push({
+        id: "bylaws",
+        label: "Corporate bylaws and initial statement of information",
+        required: true,
+      });
+    }
+
+    if (answers.hasEmployees === "yes") {
+      items.push({
+        id: "payroll",
+        label: "Payroll registration (EDD)",
+        required: true,
+      });
+    }
+
+    if (answers.dba.trim().length > 0) {
+      items.push({
+        id: "dba",
+        label: "Filed DBA certificate",
+        required: true,
+      });
+    }
+
+    return items;
+  }, [answers.dba, answers.entityType, answers.hasEmployees, answers.needsEin]);
+
+  const documents = useMemo(() => {
+    const docs = [articlesDocument, registeredAgentDocument];
+
+    if (answers.needsEin === "need" || answers.entityType !== "sole") {
+      docs.push(einDocument);
+    }
+
+    if (answers.entityType === "llc" || answers.entityType === "corporation") {
+      docs.push(operatingAgreementDocument);
+    }
+
+    if (answers.entityType === "corporation") {
+      docs.push(statementDocument);
+    }
+
+    return docs;
+  }, [answers.entityType, answers.needsEin]);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-10 px-4 pb-16 pt-10">
+      <header className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+          Guided flow
+        </p>
+        <h1 className="text-3xl font-semibold text-foreground sm:text-4xl">
+          New business formation hub
+        </h1>
+        <p className="max-w-3xl text-base text-muted-foreground">
+          Spin up a new entity, register for tax IDs, and prep compliance docs in one place. Our
+          assistant highlights which filings matter most based on your answers.
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-foreground">Business basics</h2>
+            <p className="text-sm text-muted-foreground">
+              Provide the core facts so we can populate filings and automate follow-ups.
+            </p>
+          </div>
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            AI assisted
+          </span>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {businessQuestions.map((question) => (
+            <Question
+              key={question.id}
+              id={question.id}
+              label={question.label}
+              description={question.description}
+              placeholder={question.placeholder}
+              type={question.type}
+              options={question.options}
+              className={question.className}
+              assistiveText={question.assistiveText}
+              required={question.required}
+              value={answers[question.id] ?? ""}
+              onChange={(value) =>
+                setAnswers((prev) => ({
+                  ...prev,
+                  [question.id]: value,
+                }))
+              }
+              disabled={question.disabled?.(answers)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-xl font-semibold text-foreground">Smart checklist</h2>
+          <p className="text-sm text-muted-foreground">
+            The checklist adapts to your entity type, DBA plans, and payroll needs.
+          </p>
+        </div>
+        <SmartChecklist items={checklistItems} />
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-xl font-semibold text-foreground">Document helper</h2>
+          <p className="text-sm text-muted-foreground">
+            Upload your filings for AI extraction. We'll surface EINs, filing numbers, and
+            missing signatures before you submit anything to the state.
+          </p>
+        </div>
+        <DocumentHelper documents={documents} />
+      </section>
+    </div>
+  );
+}

--- a/src/app/flows/registration-renewal/page.tsx
+++ b/src/app/flows/registration-renewal/page.tsx
@@ -1,0 +1,320 @@
+"use client";
+import { useMemo, useState } from "react";
+
+import { DocumentHelper } from "../../../components/flows/DocumentHelper";
+import { Question } from "../../../components/flows/Question";
+import {
+  ChecklistItem,
+  SmartChecklist,
+} from "../../../components/flows/SmartChecklist";
+import type { FieldHintKey } from "../../../lib/docs/fieldHints";
+
+type AnswerMap = Record<string, string>;
+
+type QuestionConfig = {
+  id: keyof AnswerMap;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  type?: "text" | "textarea" | "select" | "date" | "email";
+  options?: Array<{ value: string; label: string; description?: string }>;
+  assistiveText?: string;
+  required?: boolean;
+  className?: string;
+  disabled?: (answers: AnswerMap) => boolean;
+};
+
+const questions: QuestionConfig[] = [
+  {
+    id: "vehicleType",
+    label: "Vehicle category",
+    description: "We tailor requirements based on the type of vehicle you are renewing.",
+    type: "select",
+    options: [
+      { value: "passenger", label: "Passenger" },
+      { value: "commercial", label: "Commercial" },
+      { value: "motorcycle", label: "Motorcycle" },
+      { value: "electric", label: "Zero emission" },
+    ],
+    required: true,
+  },
+  {
+    id: "addressChanged",
+    label: "Has your mailing address changed?",
+    description: "We'll prompt for proof of address if you recently moved.",
+    type: "select",
+    options: [
+      { value: "no", label: "No" },
+      { value: "yes", label: "Yes" },
+    ],
+    required: true,
+  },
+  {
+    id: "renewalDueDate",
+    label: "Registration expiration date",
+    type: "date",
+    assistiveText:
+      "Helps us prioritize tasks if your renewal deadline is coming up soon.",
+    required: true,
+  },
+  {
+    id: "licensePlate",
+    label: "License plate number",
+    placeholder: "8ABC123",
+    assistiveText: "Seven characters, no spaces.",
+    required: true,
+  },
+  {
+    id: "insuranceCarrier",
+    label: "Insurance provider",
+    placeholder: "Carrier name",
+    className: "md:col-span-2",
+    required: true,
+  },
+  {
+    id: "insurancePolicy",
+    label: "Insurance policy number",
+    placeholder: "PCL-9081245",
+    className: "md:col-span-2",
+    required: true,
+  },
+  {
+    id: "addressProof",
+    label: "Proof of address you plan to bring",
+    description: "Utility bill, lease agreement, or mortgage statement issued within 60 days.",
+    type: "textarea",
+    className: "md:col-span-2",
+    disabled: (answers) => answers.addressChanged !== "yes",
+  },
+  {
+    id: "preferredOffice",
+    label: "Preferred DMV or AAA partner location",
+    placeholder: "Santa Ana DMV",
+    className: "md:col-span-2",
+  },
+];
+
+const baseDocuments = [
+  {
+    id: "renewal-notice",
+    title: "Renewal notice",
+    description:
+      "The letter or email reminder from the DMV includes your registration ID and fee breakdown.",
+    accept: ["application/pdf", "image/*"],
+    fields: [
+      "registrationNumber",
+      "licensePlateNumber",
+      "expirationDate",
+      "ownerLegalName",
+      "mailingAddress",
+    ] as FieldHintKey[],
+    instructions: [
+      "Capture the barcode section clearly to help the assistant extract the renewal ID.",
+      "Ensure the fee table is legible so we can itemize renewal costs.",
+    ],
+  },
+  {
+    id: "insurance-proof",
+    title: "Proof of insurance",
+    description:
+      "Upload the insurance card or declarations page showing active coverage for this vehicle.",
+    accept: ["application/pdf", "image/*"],
+    fields: [
+      "insuranceProvider",
+      "insurancePolicyNumber",
+      "insuranceEffectiveDate",
+      "ownerLegalName",
+    ] as FieldHintKey[],
+    instructions: [
+      "Include both the front and back if the policy number is split across sides.",
+    ],
+  },
+];
+
+const addressDocument = {
+  id: "address-proof",
+  title: "Proof of new address",
+  description:
+    "Upload a recent utility bill or lease so the DMV accepts your mailing change.",
+  optional: false,
+  accept: ["application/pdf", "image/*"],
+  fields: ["mailingAddress", "ownerLegalName"] as FieldHintKey[],
+  instructions: [
+    "The statement must show the service address and be dated within the last 60 days.",
+  ],
+};
+
+const smogDocument = {
+  id: "smog-certificate",
+  title: "Smog certificate",
+  description:
+    "Only required if your vehicle is gasoline powered and not exempt.",
+  accept: ["application/pdf", "image/*"],
+  optional: true,
+  fields: ["smogCertificateId", "emissionsStation", "vin"] as FieldHintKey[],
+  instructions: [
+    "Ensure the certificate shows the station ID and pass result.",
+    "Certificates older than 90 days may be rejected.",
+  ],
+};
+
+export default function RegistrationRenewalFlow() {
+  const [answers, setAnswers] = useState<AnswerMap>({
+    vehicleType: "",
+    addressChanged: "",
+    renewalDueDate: "",
+    licensePlate: "",
+    insuranceCarrier: "",
+    insurancePolicy: "",
+    addressProof: "",
+    preferredOffice: "",
+  });
+
+  const checklistItems = useMemo<ChecklistItem[]>(() => {
+    const items: ChecklistItem[] = [
+      {
+        id: "renewal-notice",
+        label: "DMV renewal notice",
+        required: true,
+      },
+      {
+        id: "id-card",
+        label: "Valid California driver license or ID",
+        required: true,
+      },
+      {
+        id: "insurance",
+        label: "Proof of liability insurance",
+        required: true,
+      },
+      {
+        id: "payment",
+        label: "Payment method for renewal fees",
+        required: true,
+      },
+    ];
+
+    if (answers.vehicleType !== "electric") {
+      items.push({
+        id: "smog",
+        label: "Smog inspection certificate",
+        required: answers.vehicleType !== "motorcycle",
+        condition: () => answers.vehicleType !== "electric",
+      });
+    }
+
+    if (answers.addressChanged === "yes") {
+      items.push({
+        id: "proof-of-address",
+        label: "Proof of new address issued within 60 days",
+        required: true,
+        condition: () => answers.addressChanged === "yes",
+      });
+    }
+
+    if (answers.vehicleType === "commercial") {
+      items.push({
+        id: "weight-cert",
+        label: "Current weight certification or CVRA paperwork",
+        required: true,
+      });
+    }
+
+    return items;
+  }, [answers.addressChanged, answers.vehicleType]);
+
+  const documentRequirements = useMemo(() => {
+    const docs = [...baseDocuments];
+
+    if (answers.vehicleType !== "electric") {
+      docs.push({
+        ...smogDocument,
+        optional: answers.vehicleType === "electric",
+      });
+    }
+
+    if (answers.addressChanged === "yes") {
+      docs.push(addressDocument);
+    }
+
+    return docs;
+  }, [answers.addressChanged, answers.vehicleType]);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-10 px-4 pb-16 pt-10">
+      <header className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+          Guided flow
+        </p>
+        <h1 className="text-3xl font-semibold text-foreground sm:text-4xl">
+          Registration renewal workflow
+        </h1>
+        <p className="max-w-3xl text-base text-muted-foreground">
+          Answer a few questions and let the assistant confirm the documents you need before
+          your DMV visit. The smart checklist updates instantly as requirements change.
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-foreground">Vehicle context</h2>
+            <p className="text-sm text-muted-foreground">
+              These answers help the assistant tailor compliance steps and highlight potential
+              blockers early.
+            </p>
+          </div>
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Updated live
+          </span>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {questions.map((question) => (
+            <Question
+              key={question.id}
+              id={question.id}
+              label={question.label}
+              description={question.description}
+              placeholder={question.placeholder}
+              type={question.type}
+              options={question.options}
+              assistiveText={question.assistiveText}
+              required={question.required}
+              value={answers[question.id] ?? ""}
+              onChange={(value) =>
+                setAnswers((prev) => ({
+                  ...prev,
+                  [question.id]: value,
+                }))
+              }
+              className={question.className}
+              disabled={question.disabled?.(answers)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-xl font-semibold text-foreground">Smart checklist</h2>
+          <p className="text-sm text-muted-foreground">
+            Requirements shift based on your answers. Anything marked with a red asterisk is
+            required before the DMV will process the renewal.
+          </p>
+        </div>
+        <SmartChecklist items={checklistItems} />
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-xl font-semibold text-foreground">Document helper</h2>
+          <p className="text-sm text-muted-foreground">
+            Upload a document and the assistant will extract the key fields, flag missing
+            sections, and summarize next steps.
+          </p>
+        </div>
+        <DocumentHelper documents={documentRequirements} />
+      </section>
+    </div>
+  );
+}

--- a/src/app/flows/title-transfer/page.tsx
+++ b/src/app/flows/title-transfer/page.tsx
@@ -1,0 +1,348 @@
+"use client";
+import { useMemo, useState } from "react";
+
+import { DocumentHelper } from "../../../components/flows/DocumentHelper";
+import { Question } from "../../../components/flows/Question";
+import {
+  ChecklistItem,
+  SmartChecklist,
+} from "../../../components/flows/SmartChecklist";
+import type { FieldHintKey } from "../../../lib/docs/fieldHints";
+
+type TransferAnswers = {
+  saleType: string;
+  hasLien: string;
+  odometerDisclosure: string;
+  vehicleYear: string;
+  salePrice: string;
+  saleDate: string;
+  buyerEmail: string;
+  buyerPhone: string;
+  notes: string;
+};
+
+type TransferQuestion = {
+  id: keyof TransferAnswers;
+  label: string;
+  description?: string;
+  type?: "text" | "textarea" | "select" | "date" | "email" | "tel";
+  placeholder?: string;
+  options?: Array<{ value: string; label: string; description?: string }>;
+  className?: string;
+  assistiveText?: string;
+  required?: boolean;
+};
+
+const transferQuestions: TransferQuestion[] = [
+  {
+    id: "saleType",
+    label: "What type of sale is this?",
+    description: "Different sale types adjust whether a smog check or bill of sale is needed.",
+    type: "select",
+    options: [
+      { value: "private", label: "Private party" },
+      { value: "dealer", label: "Dealer" },
+      { value: "family", label: "Family gift" },
+      { value: "inheritance", label: "Inheritance" },
+    ],
+    required: true,
+  },
+  {
+    id: "hasLien",
+    label: "Is there a lien on the title?",
+    description: "We'll check for lien release requirements.",
+    type: "select",
+    options: [
+      { value: "no", label: "No" },
+      { value: "yes", label: "Yes" },
+    ],
+    required: true,
+  },
+  {
+    id: "vehicleYear",
+    label: "Vehicle model year",
+    placeholder: "2019",
+    assistiveText: "Used to determine odometer disclosure requirements.",
+    required: true,
+  },
+  {
+    id: "odometerDisclosure",
+    label: "Odometer disclosure completed?",
+    description: "For vehicles under 20 years old, the buyer and seller must sign.",
+    type: "select",
+    options: [
+      { value: "not-started", label: "Not yet" },
+      { value: "in-progress", label: "In progress" },
+      { value: "complete", label: "Yes, completed" },
+    ],
+    required: true,
+  },
+  {
+    id: "saleDate",
+    label: "Sale date",
+    type: "date",
+    required: true,
+  },
+  {
+    id: "salePrice",
+    label: "Sale price",
+    placeholder: "$18,250",
+    required: true,
+  },
+  {
+    id: "buyerEmail",
+    label: "Buyer email",
+    type: "email",
+    placeholder: "buyer@email.com",
+    assistiveText: "We'll send digital signature requests here if needed.",
+    className: "md:col-span-2",
+  },
+  {
+    id: "buyerPhone",
+    label: "Buyer phone",
+    type: "tel",
+    placeholder: "(555) 555-0192",
+    className: "md:col-span-2",
+  },
+  {
+    id: "notes",
+    label: "Any special circumstances?",
+    type: "textarea",
+    placeholder: "Vehicle inherited, smog exemption letter submitted...",
+    className: "md:col-span-2",
+  },
+];
+
+const titleDocument = {
+  id: "title-document",
+  title: "California Certificate of Title",
+  description: "Scan or upload the front and back of the current title (pink slip).",
+  accept: ["application/pdf", "image/*"],
+  fields: [
+    "ownerLegalName",
+    "buyerName",
+    "sellerName",
+    "vin",
+    "titleNumber",
+  ] as FieldHintKey[],
+  instructions: [
+    "Confirm the seller signatures are complete on line 1 and line 2 if applicable.",
+    "Ensure no white-out or corrections appear—DMV rejects altered titles.",
+  ],
+};
+
+const billOfSaleDocument = {
+  id: "bill-of-sale",
+  title: "Bill of sale",
+  description:
+    "Used when the purchase price or special terms need to be documented in addition to the title.",
+  accept: ["application/pdf", "image/*"],
+  fields: [
+    "buyerName",
+    "sellerName",
+    "saleDate",
+    "purchasePrice",
+    "vin",
+  ] as FieldHintKey[],
+  instructions: [
+    "Verify both parties have signed and the purchase price matches the title.",
+  ],
+};
+
+const odometerDocument = {
+  id: "odometer",
+  title: "Odometer disclosure",
+  description:
+    "Form REG 262 or the federal odometer disclosure statement required for vehicles under 20 years old.",
+  accept: ["application/pdf", "image/*"],
+  fields: ["odometerReading", "buyerName", "sellerName", "vin"] as FieldHintKey[],
+  instructions: [
+    "Ensure the mileage is clearly legible and both signatures are present.",
+  ],
+};
+
+const lienReleaseDocument = {
+  id: "lien-release",
+  title: "Lien release",
+  description: "Needed when the title lists a financial institution as lienholder.",
+  accept: ["application/pdf", "image/*"],
+  fields: ["lienholder", "titleNumber", "vin"] as FieldHintKey[],
+  instructions: [
+    "Upload the original lien release letter or stamped title indicating lien satisfied.",
+  ],
+};
+
+const smogDocument = {
+  id: "smog",
+  title: "Smog certificate",
+  description:
+    "Required for most gasoline vehicles unless exempt by age or location.",
+  accept: ["application/pdf", "image/*"],
+  optional: true,
+  fields: ["smogCertificateId", "emissionsStation", "vin"] as FieldHintKey[],
+  instructions: [
+    "Verify the certificate date is within 90 days of the transfer.",
+  ],
+};
+
+export default function TitleTransferFlow() {
+  const [answers, setAnswers] = useState<TransferAnswers>({
+    saleType: "",
+    hasLien: "",
+    odometerDisclosure: "",
+    vehicleYear: "",
+    salePrice: "",
+    saleDate: "",
+    buyerEmail: "",
+    buyerPhone: "",
+    notes: "",
+  });
+
+  const checklistItems = useMemo<ChecklistItem[]>(() => {
+    const items: ChecklistItem[] = [
+      { id: "title", label: "Signed title (pink slip)", required: true },
+      {
+        id: "buyer-id",
+        label: "Buyer and seller photo ID",
+        required: true,
+      },
+      {
+        id: "bill-of-sale",
+        label: "Bill of sale",
+        required: answers.saleType !== "family" && answers.saleType !== "inheritance",
+        condition: () => answers.saleType !== "family" && answers.saleType !== "inheritance",
+      },
+    ];
+
+    if (answers.hasLien === "yes") {
+      items.push({
+        id: "lien-release",
+        label: "Lien release letter or notarized payoff statement",
+        required: true,
+        condition: () => answers.hasLien === "yes",
+      });
+    }
+
+    const vehicleYear = Number.parseInt(answers.vehicleYear, 10);
+    const needsOdometer = Number.isFinite(vehicleYear)
+      ? new Date().getFullYear() - vehicleYear < 20
+      : true;
+
+    if (needsOdometer) {
+      items.push({
+        id: "odometer",
+        label: "Completed odometer disclosure",
+        required: true,
+      });
+    }
+
+    if (answers.saleType !== "family" && answers.saleType !== "inheritance") {
+      items.push({
+        id: "smog",
+        label: "Smog inspection certificate",
+        required: true,
+        condition: () => answers.saleType !== "dealer",
+      });
+    }
+
+    return items;
+  }, [answers.hasLien, answers.saleType, answers.vehicleYear]);
+
+  const documents = useMemo(() => {
+    const docs = [titleDocument, billOfSaleDocument];
+
+    const vehicleYear = Number.parseInt(answers.vehicleYear, 10);
+    const needsOdometer = Number.isFinite(vehicleYear)
+      ? new Date().getFullYear() - vehicleYear < 20
+      : true;
+
+    if (needsOdometer) {
+      docs.push(odometerDocument);
+    }
+
+    if (answers.hasLien === "yes") {
+      docs.push(lienReleaseDocument);
+    }
+
+    if (answers.saleType !== "family" && answers.saleType !== "inheritance") {
+      docs.push(smogDocument);
+    }
+
+    return docs;
+  }, [answers.hasLien, answers.saleType, answers.vehicleYear]);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-10 px-4 pb-16 pt-10">
+      <header className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+          Guided flow
+        </p>
+        <h1 className="text-3xl font-semibold text-foreground sm:text-4xl">
+          Title transfer assistant
+        </h1>
+        <p className="max-w-3xl text-base text-muted-foreground">
+          Manage private-party or dealer transfers with confidence. Smart automations surface
+          missing paperwork and help you finalize signatures faster.
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-foreground">Transaction details</h2>
+            <p className="text-sm text-muted-foreground">
+              Your answers drive which forms we prep, from lien releases to odometer statements.
+            </p>
+          </div>
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Live preview
+          </span>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {transferQuestions.map((question) => (
+            <Question
+              key={question.id}
+              id={question.id}
+              label={question.label}
+              description={question.description}
+              placeholder={question.placeholder}
+              type={question.type}
+              options={question.options}
+              className={question.className}
+              assistiveText={question.assistiveText}
+              required={question.required}
+              value={answers[question.id] ?? ""}
+              onChange={(value) =>
+                setAnswers((prev) => ({
+                  ...prev,
+                  [question.id]: value,
+                }))
+              }
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-xl font-semibold text-foreground">Smart checklist</h2>
+          <p className="text-sm text-muted-foreground">
+            We highlight every document the DMV expects so nothing is missed on transfer day.
+          </p>
+        </div>
+        <SmartChecklist items={checklistItems} />
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-xl font-semibold text-foreground">Document helper</h2>
+          <p className="text-sm text-muted-foreground">
+            Upload drafts for AI review. We extract VINs, parties, signatures, and alert you if
+            something is missing.
+          </p>
+        </div>
+        <DocumentHelper documents={documents} />
+      </section>
+    </div>
+  );
+}

--- a/src/components/flows/DocumentHelper.tsx
+++ b/src/components/flows/DocumentHelper.tsx
@@ -1,0 +1,347 @@
+"use client";
+import {
+  ChangeEvent,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { extractImage } from "../../lib/docs/extractImage";
+import { extractPdf } from "../../lib/docs/extractPdf";
+import {
+  fieldHints,
+  FieldHint,
+  FieldHintKey,
+} from "../../lib/docs/fieldHints";
+
+type DocumentRequirement = {
+  id: string;
+  title: string;
+  description?: string;
+  optional?: boolean;
+  accept?: string[];
+  instructions?: string[];
+  fields?: FieldHintKey[];
+};
+
+type ExtractionSnapshot = {
+  text: string;
+  error?: string;
+  fileName?: string;
+  updatedAt?: Date;
+};
+
+export type DocumentHelperProps = {
+  documents: DocumentRequirement[];
+  className?: string;
+};
+
+function classNames(
+  ...classes: Array<string | null | false | undefined>
+): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+function formatTimestamp(date?: Date) {
+  if (!date) return "";
+  try {
+    return `${date.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    })} · ${date.toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+    })}`;
+  } catch (error) {
+    return date.toISOString();
+  }
+}
+
+function sanitizeExtraction(text: string) {
+  return text
+    .replace(/\u0000/g, "")
+    .replace(/\s+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export function DocumentHelper({
+  documents,
+  className,
+}: DocumentHelperProps) {
+  const [activeId, setActiveId] = useState(() => documents[0]?.id ?? "");
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+  const [extractions, setExtractions] = useState<Record<string, ExtractionSnapshot>>({});
+
+  useEffect(() => {
+    if (!documents.length) {
+      setActiveId("");
+      return;
+    }
+
+    if (!documents.some((doc) => doc.id === activeId)) {
+      setActiveId(documents[0].id);
+    }
+  }, [activeId, documents]);
+
+  const activeDoc = useMemo(() => {
+    if (!documents.length) {
+      return undefined;
+    }
+
+    return documents.find((doc) => doc.id === activeId) ?? documents[0];
+  }, [activeId, documents]);
+
+  const activeHints = useMemo(() => {
+    if (!activeDoc?.fields?.length) {
+      return [] as Array<{ key: FieldHintKey; hint: FieldHint }>;
+    }
+
+    return activeDoc.fields
+      .map((key) => {
+        const hint = fieldHints[key];
+        if (!hint) {
+          return null;
+        }
+
+        return { key, hint };
+      })
+      .filter((entry): entry is { key: FieldHintKey; hint: FieldHint } =>
+        Boolean(entry)
+      );
+  }, [activeDoc]);
+
+  const handleFileChange = async (
+    docId: string,
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+
+    if (!file) {
+      return;
+    }
+
+    setLoadingId(docId);
+
+    try {
+      let text = "";
+      if (
+        file.type === "application/pdf" ||
+        file.name.toLowerCase().endsWith(".pdf")
+      ) {
+        text = await extractPdf(file);
+      } else if (file.type.startsWith("image/")) {
+        text = await extractImage(file);
+      } else {
+        text = await file.text();
+      }
+
+      setExtractions((prev) => ({
+        ...prev,
+        [docId]: {
+          text: sanitizeExtraction(text),
+          fileName: file.name,
+          updatedAt: new Date(),
+        },
+      }));
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to analyze the selected document.";
+
+      setExtractions((prev) => ({
+        ...prev,
+        [docId]: {
+          text: "",
+          error: message,
+          fileName: file.name,
+          updatedAt: new Date(),
+        },
+      }));
+    } finally {
+      setLoadingId(null);
+    }
+  };
+
+  return (
+    <div
+      className={classNames(
+        "overflow-hidden rounded-2xl border border-border bg-card shadow-sm",
+        className
+      )}
+    >
+      <div className="grid gap-0 lg:grid-cols-[260px,1fr]">
+        <div className="border-b border-border bg-muted/40 p-4 lg:border-b-0 lg:border-r">
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Documents
+          </div>
+          <div className="mt-3 space-y-2">
+            {documents.map((doc) => {
+              const isActive = doc.id === (activeDoc?.id ?? activeId);
+              return (
+                <button
+                  type="button"
+                  key={doc.id}
+                  onClick={() => setActiveId(doc.id)}
+                  className={classNames(
+                    "w-full rounded-xl border px-3 py-2 text-left text-sm transition",
+                    isActive
+                      ? "border-primary/60 bg-background text-foreground shadow-sm"
+                      : "border-transparent bg-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium">{doc.title}</span>
+                    {doc.optional && (
+                      <span className="text-xs font-medium uppercase text-muted-foreground">
+                        Optional
+                      </span>
+                    )}
+                  </div>
+                  {doc.description && (
+                    <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                      {doc.description}
+                    </p>
+                  )}
+                </button>
+              );
+            })}
+            {!documents.length && (
+              <div className="rounded-lg border border-dashed border-border/60 bg-muted/40 p-3 text-xs text-muted-foreground">
+                Add document requirements to configure the helper.
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="p-6">
+          {activeDoc ? (
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-lg font-semibold text-foreground">
+                    {activeDoc.title}
+                  </h3>
+                  {activeDoc.optional && (
+                    <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Optional
+                    </span>
+                  )}
+                </div>
+                {activeDoc.description && (
+                  <p className="text-sm text-muted-foreground">
+                    {activeDoc.description}
+                  </p>
+                )}
+                {activeDoc.instructions?.length ? (
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                    {activeDoc.instructions.map((instruction) => (
+                      <li key={instruction}>{instruction}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+              <div className="space-y-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <label
+                    htmlFor={`${activeDoc.id}-upload`}
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Upload for AI review
+                  </label>
+                  <input
+                    id={`${activeDoc.id}-upload`}
+                    type="file"
+                    accept={activeDoc.accept?.join(",")}
+                    onChange={(event) => handleFileChange(activeDoc.id, event)}
+                    className="w-full max-w-sm cursor-pointer rounded-lg border border-dashed border-border bg-background px-3 py-2 text-sm text-muted-foreground transition hover:border-primary/60 hover:text-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  />
+                  {loadingId === activeDoc.id && (
+                    <span className="text-sm text-muted-foreground">
+                      Analyzing…
+                    </span>
+                  )}
+                  {extractions[activeDoc.id]?.updatedAt && (
+                    <span className="text-xs text-muted-foreground">
+                      {extractions[activeDoc.id]?.fileName}
+                      {" · "}
+                      {formatTimestamp(extractions[activeDoc.id]?.updatedAt)}
+                    </span>
+                  )}
+                </div>
+                {extractions[activeDoc.id]?.error && (
+                  <p className="text-sm text-red-500">
+                    {extractions[activeDoc.id]?.error}
+                  </p>
+                )}
+              </div>
+              {activeHints.length ? (
+                <div className="space-y-3">
+                  <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Key fields to verify
+                  </h4>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {activeHints.map(({ key, hint }) => (
+                      <div
+                        key={key}
+                        className="rounded-xl border border-border/60 bg-muted/30 p-4"
+                      >
+                        <p className="text-sm font-semibold text-foreground">
+                          {hint.title}
+                        </p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {hint.description}
+                        </p>
+                        {hint.examples?.length ? (
+                          <p className="mt-2 text-xs text-muted-foreground">
+                            <span className="font-medium text-foreground">
+                              Examples:
+                            </span>{" "}
+                            {hint.examples.join(", ")}
+                          </p>
+                        ) : null}
+                        {hint.aiTips?.length ? (
+                          <ul className="mt-2 list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+                            {hint.aiTips.map((tip) => (
+                              <li key={tip}>{tip}</li>
+                            ))}
+                          </ul>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              <div className="space-y-2">
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Extracted text preview
+                </h4>
+                <div className="min-h-[160px] rounded-xl border border-dashed border-border/70 bg-muted/20 p-4">
+                  {loadingId === activeDoc.id ? (
+                    <p className="text-sm text-muted-foreground">
+                      Running extraction…
+                    </p>
+                  ) : extractions[activeDoc.id]?.text ? (
+                    <pre className="max-h-64 whitespace-pre-wrap break-words text-sm text-foreground">
+                      {extractions[activeDoc.id]?.text}
+                    </pre>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      Upload {activeDoc.title.toLowerCase()} to see the
+                      extracted details here.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-xl border border-dashed border-border/60 bg-muted/20 p-6 text-sm text-muted-foreground">
+              Add at least one document to begin using the helper.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/flows/Question.tsx
+++ b/src/components/flows/Question.tsx
@@ -1,0 +1,168 @@
+"use client";
+import { ChangeEvent, useId, useMemo } from "react";
+
+type QuestionOption = {
+  label: string;
+  value: string;
+  description?: string;
+};
+
+type QuestionType =
+  | "text"
+  | "textarea"
+  | "select"
+  | "date"
+  | "email"
+  | "number"
+  | "tel";
+
+type QuestionProps = {
+  id: string;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  required?: boolean;
+  value?: string;
+  onChange?: (value: string) => void;
+  type?: QuestionType;
+  options?: QuestionOption[];
+  assistiveText?: string;
+  className?: string;
+  disabled?: boolean;
+};
+
+function classNames(
+  ...classes: Array<string | null | false | undefined>
+): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function Question({
+  id,
+  label,
+  description,
+  placeholder,
+  required,
+  value = "",
+  onChange,
+  type = "text",
+  options = [],
+  assistiveText,
+  className,
+  disabled,
+}: QuestionProps) {
+  const generatedId = useId();
+  const controlId = `${id}-${generatedId}`;
+
+  const handleChange = (
+    event: ChangeEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >
+  ) => {
+    onChange?.(event.target.value);
+  };
+
+  const selectedOption = useMemo(() => {
+    if (type !== "select" || !options.length) {
+      return undefined;
+    }
+
+    return options.find((option) => option.value === value);
+  }, [options, type, value]);
+
+  const descriptionId = description ? `${controlId}-description` : undefined;
+  const assistiveId = assistiveText ? `${controlId}-assistive` : undefined;
+  const optionId =
+    selectedOption?.description && type === "select"
+      ? `${controlId}-selected`
+      : undefined;
+
+  const describedBy = [descriptionId, assistiveId, optionId]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={classNames(
+        "flex flex-col gap-3 rounded-xl border border-border bg-card/60 p-5 shadow-sm transition",
+        disabled ? "opacity-60" : undefined,
+        className
+      )}
+    >
+      <div className="space-y-1">
+        <label
+          htmlFor={controlId}
+          className="text-sm font-semibold text-foreground"
+        >
+          {label}
+          {required && <span className="ml-1 text-red-500">*</span>}
+        </label>
+        {description && (
+          <p id={descriptionId} className="text-sm text-muted-foreground">
+            {description}
+          </p>
+        )}
+      </div>
+      <div>
+        {type === "select" ? (
+          <select
+            id={controlId}
+            name={id}
+            value={value}
+            onChange={handleChange}
+            className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            aria-describedby={describedBy || undefined}
+            required={required}
+            disabled={disabled}
+          >
+            <option value="">
+              {placeholder ?? "Select an option"}
+            </option>
+            {options.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        ) : type === "textarea" ? (
+          <textarea
+            id={controlId}
+            name={id}
+            value={value}
+            onChange={handleChange}
+            placeholder={placeholder}
+            className="min-h-[120px] w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            aria-describedby={describedBy || undefined}
+            required={required}
+            disabled={disabled}
+          />
+        ) : (
+          <input
+            id={controlId}
+            name={id}
+            type={type}
+            value={value}
+            onChange={handleChange}
+            placeholder={placeholder}
+            className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            aria-describedby={describedBy || undefined}
+            required={required}
+            disabled={disabled}
+          />
+        )}
+      </div>
+      <div className="space-y-2">
+        {assistiveText && (
+          <p id={assistiveId} className="text-xs text-muted-foreground">
+            {assistiveText}
+          </p>
+        )}
+        {selectedOption?.description && (
+          <p id={optionId} className="text-xs text-muted-foreground">
+            {selectedOption.description}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/flows/SmartChecklist.tsx
+++ b/src/components/flows/SmartChecklist.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useState } from "react";
+
+export type ChecklistItem = {
+  id: string;
+  label: string;
+  required?: boolean;
+  condition?: (answers: Record<string, string>) => boolean;
+};
+
+export function SmartChecklist({ items }: { items: ChecklistItem[] }) {
+  const [answers] = useState<Record<string, string>>({});
+
+  const visible = items.filter((item) =>
+    item.condition ? item.condition(answers) : true
+  );
+
+  return (
+    <ul className="list-disc space-y-2 pl-5">
+      {visible.map((item) => (
+        <li key={item.id}>
+          <span className={item.required ? "font-semibold" : ""}>{item.label}</span>
+          {item.required && <span className="text-red-500">*</span>}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/docs/extractImage.ts
+++ b/src/lib/docs/extractImage.ts
@@ -1,0 +1,210 @@
+export type ImageSource =
+  | Blob
+  | File
+  | string
+  | CanvasImageSource;
+
+export async function extractImage(source: ImageSource): Promise<string> {
+  if (typeof window === "undefined") {
+    throw new Error("Image extraction can only run in the browser environment.");
+  }
+
+  const resolvedSource = await resolveCanvasSource(source);
+
+  try {
+    const text = await detectText(resolvedSource);
+    if (text) {
+      return text;
+    }
+  } catch (error) {
+    console.warn("Text detection failed", error);
+  }
+
+  return await summarizeImage(resolvedSource);
+}
+
+async function resolveCanvasSource(
+  source: ImageSource
+): Promise<CanvasImageSource> {
+  if (source instanceof Blob) {
+    return await loadImageFromBlob(source);
+  }
+
+  if (typeof source === "string") {
+    const response = await fetch(source);
+    if (!response.ok) {
+      throw new Error("Unable to load image from the provided URL.");
+    }
+
+    const blob = await response.blob();
+    return await loadImageFromBlob(blob);
+  }
+
+  if (isCanvasImageSource(source)) {
+    return source;
+  }
+
+  throw new Error("Unsupported image source provided for extraction.");
+}
+
+async function detectText(source: CanvasImageSource): Promise<string> {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  const detector = (window as Window & { TextDetector?: new () => any }).TextDetector;
+
+  if (!detector) {
+    return "";
+  }
+
+  const instance = new detector();
+  const detections: Array<{ rawValue?: string; data?: string }> =
+    await instance.detect(source);
+
+  const text = detections
+    .map((item) => item.rawValue ?? item.data ?? "")
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+
+  return text;
+}
+
+async function summarizeImage(source: CanvasImageSource): Promise<string> {
+  const canvas = await ensureCanvas(source);
+  const context = canvas.getContext("2d");
+
+  if (!context) {
+    throw new Error(
+      "Unable to analyze the image. Try uploading a PDF or a higher quality scan."
+    );
+  }
+
+  const { data, width, height } = context.getImageData(
+    0,
+    0,
+    canvas.width,
+    canvas.height
+  );
+
+  let darkPixels = 0;
+  const totalPixels = width * height;
+
+  for (let index = 0; index < data.length; index += 4) {
+    const luminance =
+      data[index] * 0.2126 + data[index + 1] * 0.7152 + data[index + 2] * 0.0722;
+    if (luminance < 140) {
+      darkPixels += 1;
+    }
+  }
+
+  const coverage = Math.min(100, (darkPixels / totalPixels) * 100);
+  const formattedCoverage = Math.round(coverage * 10) / 10;
+
+  return [
+    "Automatic OCR isn't available in this browser.",
+    `Resolution: ${canvas.width}×${canvas.height}px`,
+    `Estimated ink coverage: ${formattedCoverage}%`,
+    "Upload a clearer image or a PDF for the best AI results.",
+  ].join("\n");
+}
+
+async function loadImageFromBlob(blob: Blob): Promise<CanvasImageSource> {
+  if (typeof window === "undefined") {
+    throw new Error("Image processing is only supported in the browser.");
+  }
+
+  if (typeof createImageBitmap === "function") {
+    try {
+      return await createImageBitmap(blob);
+    } catch (error) {
+      console.warn("createImageBitmap failed, falling back to HTMLImageElement", error);
+    }
+  }
+
+  const objectUrl = URL.createObjectURL(blob);
+
+  try {
+    const image = await loadImageElement(objectUrl);
+    return image;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+function loadImageElement(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = "anonymous";
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("Failed to load image for analysis."));
+    image.src = src;
+  });
+}
+
+function isCanvasImageSource(value: unknown): value is CanvasImageSource {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return (
+    value instanceof HTMLCanvasElement ||
+    (typeof ImageBitmap !== "undefined" && value instanceof ImageBitmap) ||
+    value instanceof HTMLImageElement
+  );
+}
+
+async function ensureCanvas(source: CanvasImageSource): Promise<HTMLCanvasElement> {
+  if (source instanceof HTMLCanvasElement) {
+    return source;
+  }
+
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+
+  if (!context) {
+    throw new Error("Unable to create a canvas context for image analysis.");
+  }
+
+  const width = getSourceWidth(source);
+  const height = getSourceHeight(source);
+
+  canvas.width = Math.max(1, width);
+  canvas.height = Math.max(1, height);
+  context.drawImage(source, 0, 0, canvas.width, canvas.height);
+
+  return canvas;
+}
+
+function getSourceWidth(source: CanvasImageSource): number {
+  if (source instanceof HTMLCanvasElement) {
+    return source.width;
+  }
+
+  if (typeof ImageBitmap !== "undefined" && source instanceof ImageBitmap) {
+    return source.width;
+  }
+
+  if (source instanceof HTMLImageElement) {
+    return source.naturalWidth || source.width;
+  }
+
+  return 0;
+}
+
+function getSourceHeight(source: CanvasImageSource): number {
+  if (source instanceof HTMLCanvasElement) {
+    return source.height;
+  }
+
+  if (typeof ImageBitmap !== "undefined" && source instanceof ImageBitmap) {
+    return source.height;
+  }
+
+  if (source instanceof HTMLImageElement) {
+    return source.naturalHeight || source.height;
+  }
+
+  return 0;
+}

--- a/src/lib/docs/extractPdf.ts
+++ b/src/lib/docs/extractPdf.ts
@@ -1,0 +1,103 @@
+const latin1Decoder = new TextDecoder("latin1", { fatal: false });
+const utf8Decoder = new TextDecoder("utf-8", { fatal: false });
+
+type PdfSource = Blob | ArrayBuffer | Uint8Array;
+
+export async function extractPdf(source: PdfSource): Promise<string> {
+  const bytes = await toUint8Array(source);
+  const operatorText = extractFromOperators(bytes);
+
+  if (operatorText) {
+    return normalizeWhitespace(operatorText);
+  }
+
+  return normalizeWhitespace(fallbackDecode(bytes));
+}
+
+async function toUint8Array(source: PdfSource): Promise<Uint8Array> {
+  if (source instanceof Uint8Array) {
+    return source;
+  }
+
+  if (source instanceof ArrayBuffer) {
+    return new Uint8Array(source);
+  }
+
+  if (source instanceof Blob) {
+    return new Uint8Array(await source.arrayBuffer());
+  }
+
+  throw new Error("Unsupported PDF source provided for extraction.");
+}
+
+function extractFromOperators(bytes: Uint8Array): string {
+  const raw = latin1Decoder.decode(bytes);
+  const blocks = raw.match(/BT[\s\S]*?ET/g);
+
+  if (!blocks) {
+    return "";
+  }
+
+  const segments: string[] = [];
+
+  for (const block of blocks) {
+    const matches = block.match(/\((?:\\\)|\\\(|\\\\|[^()])*?\)|<([0-9A-Fa-f\s]+)>/g);
+
+    if (!matches) {
+      continue;
+    }
+
+    for (const match of matches) {
+      if (match.startsWith("<")) {
+        const hex = match.slice(1, -1).replace(/\s+/g, "");
+        segments.push(decodeHexString(hex));
+      } else {
+        const content = match.slice(1, -1);
+        segments.push(unescapePdfString(content));
+      }
+    }
+  }
+
+  return segments.join(" ").trim();
+}
+
+function decodeHexString(hex: string): string {
+  if (!hex || hex.length % 2 !== 0) {
+    return "";
+  }
+
+  const values = new Uint8Array(hex.length / 2);
+
+  for (let index = 0; index < hex.length; index += 2) {
+    values[index / 2] = Number.parseInt(hex.slice(index, index + 2), 16);
+  }
+
+  return utf8Decoder.decode(values);
+}
+
+function unescapePdfString(value: string): string {
+  return value
+    .replace(/\\n/g, "\n")
+    .replace(/\\r/g, "\r")
+    .replace(/\\t/g, "\t")
+    .replace(/\\b/g, "\b")
+    .replace(/\\f/g, "\f")
+    .replace(/\\\(/g, '(')
+    .replace(/\\\)/g, ')')
+    .replace(/\\\\/g, "\\")
+    .replace(/\\([0-7]{1,3})/g, (_, octal: string) =>
+      String.fromCharCode(Number.parseInt(octal, 8))
+    );
+}
+
+function fallbackDecode(bytes: Uint8Array): string {
+  const decoded = utf8Decoder.decode(bytes);
+  return decoded
+    .replace(/stream[\s\S]*?endstream/g, " ")
+    .replace(/[^\x09\x0A\x0D\x20-\x7E]+/g, " ")
+    .replace(/\s+/g, " ");
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s{2,}/g, " ").replace(/\s*\n\s*/g, "\n").trim();
+}

--- a/src/lib/docs/fieldHints.ts
+++ b/src/lib/docs/fieldHints.ts
@@ -1,0 +1,258 @@
+export type FieldHint = {
+  title: string;
+  description: string;
+  examples?: string[];
+  aiTips?: string[];
+};
+
+export const fieldHints = {
+  ownerLegalName: {
+    title: "Registered owner legal name",
+    description:
+      "Use the full legal name as it appears on the DMV record, including middle initials if listed.",
+    examples: ["Jordan A. Rivera", "Taylor Chen"],
+    aiTips: [
+      "Cross-check the owner name with the signature line to ensure consistency.",
+      "Flag any nicknames or abbreviations so the agent can confirm them manually.",
+    ],
+  },
+  mailingAddress: {
+    title: "Mailing address",
+    description:
+      "Capture the complete mailing address, including suite or apartment numbers.",
+    examples: ["742 Market Street, Suite 320, San Francisco, CA 94102"],
+    aiTips: [
+      "Normalize street abbreviations (St., Rd., Ave.) to the DMV preferred format.",
+      "If a PO Box appears, highlight it so a physical address can be requested if needed.",
+    ],
+  },
+  registrationNumber: {
+    title: "Registration number",
+    description: "Unique identifier assigned to the vehicle registration record.",
+    examples: ["REG-4928301", "A1537284"],
+    aiTips: [
+      "Strip out hyphens when passing data to backend systems unless they are mandatory.",
+    ],
+  },
+  licensePlateNumber: {
+    title: "License plate number",
+    description: "Standard California license plate (usually 7 characters).",
+    examples: ["8XYZ321", "7ABC456"],
+    aiTips: [
+      "Normalize the string to uppercase to avoid casing mismatches.",
+      "Flag specialty plates by checking for non-alphanumeric characters.",
+    ],
+  },
+  expirationDate: {
+    title: "Expiration date",
+    description: "Date the registration expires. Often located near the top of the notice.",
+    examples: ["08/31/2024", "2025-01-15"],
+    aiTips: [
+      "Support both numeric and written month formats (e.g., 'Aug 31, 2024').",
+      "Surface a reminder if the expiration date is within 30 days of today.",
+    ],
+  },
+  insuranceProvider: {
+    title: "Insurance provider",
+    description:
+      "The company that issued the vehicle's liability insurance policy.",
+    examples: ["State Farm", "Mercury Insurance"],
+    aiTips: [
+      "Map common abbreviations (e.g., 'AAA') to the standard carrier name used in your CRM.",
+    ],
+  },
+  insurancePolicyNumber: {
+    title: "Policy number",
+    description: "Unique identifier for the auto insurance policy.",
+    examples: ["PCL-9081245", "CA-123-4567"],
+    aiTips: [
+      "Trim spaces and normalize dashes so downstream validations pass.",
+      "Highlight when multiple policy numbers appear to reduce ambiguity.",
+    ],
+  },
+  insuranceEffectiveDate: {
+    title: "Policy effective date",
+    description: "The start date of the active insurance policy term.",
+    examples: ["02/15/2024"],
+    aiTips: [
+      "If the document lists effective and expiration dates, capture both for compliance.",
+    ],
+  },
+  smogCertificateId: {
+    title: "Smog certificate ID",
+    description: "Barcode or control number associated with the smog check certificate.",
+    examples: ["E-9382716"],
+    aiTips: [
+      "Ensure the certificate date is within the DMV acceptance window (typically 90 days).",
+    ],
+  },
+  emissionsStation: {
+    title: "Test station",
+    description: "Name or number of the smog inspection station.",
+    examples: ["Star Smog Center #4521"],
+    aiTips: [
+      "Capture the station number so agents can audit STAR vs. non-STAR locations.",
+    ],
+  },
+  vin: {
+    title: "Vehicle identification number (VIN)",
+    description: "17-character VIN used to identify the vehicle.",
+    examples: ["1HGCM82633A123456"],
+    aiTips: [
+      "Validate that the VIN is 17 characters and remove spaces or dashes.",
+      "Highlight if the VIN decoded year mismatches the paperwork year.",
+    ],
+  },
+  buyerName: {
+    title: "Buyer name",
+    description: "Primary buyer listed on the title or bill of sale.",
+    examples: ["Morgan Patel"],
+    aiTips: [
+      "Support multiple buyers by splitting on 'and' or '&' when present.",
+    ],
+  },
+  sellerName: {
+    title: "Seller name",
+    description: "Current owner who is transferring the vehicle.",
+    examples: ["Jamie Lee"],
+    aiTips: [
+      "Highlight mismatches between the seller and the existing registered owner.",
+    ],
+  },
+  saleDate: {
+    title: "Sale date",
+    description: "Date the transfer was executed.",
+    examples: ["03/22/2024"],
+    aiTips: [
+      "Trigger a late transfer warning if the sale date is more than 10 days old.",
+    ],
+  },
+  purchasePrice: {
+    title: "Purchase price",
+    description: "Total amount paid for the vehicle.",
+    examples: ["$18,250", "$2,500"],
+    aiTips: [
+      "Strip currency symbols and commas before sending to tax calculations.",
+    ],
+  },
+  odometerReading: {
+    title: "Odometer reading",
+    description: "Mileage recorded at the time of sale.",
+    examples: ["67,154"],
+    aiTips: [
+      "Normalize to a numeric value and flag readings below the previous registration mileage.",
+    ],
+  },
+  lienholder: {
+    title: "Lienholder",
+    description: "Financial institution holding a lien on the vehicle, if applicable.",
+    examples: ["Ally Financial"],
+    aiTips: [
+      "Only mark lien release as satisfied when the document explicitly states it.",
+    ],
+  },
+  titleNumber: {
+    title: "Title number",
+    description: "Official DMV title identifier, often top right on the pink slip.",
+    examples: ["CA-02837461"],
+    aiTips: [
+      "Use the title number to cross-reference with prior DMV submissions for duplicates.",
+    ],
+  },
+  businessLegalName: {
+    title: "Business legal name",
+    description: "The exact entity name registered with the Secretary of State.",
+    examples: ["Harbor City Logistics LLC"],
+    aiTips: [
+      "Flag differences between legal name and DBA so filings include both when required.",
+    ],
+  },
+  businessAddress: {
+    title: "Business address",
+    description: "Primary business address used on formation documents.",
+    examples: ["1250 Harbor Blvd, Suite 200, Long Beach, CA 90802"],
+    aiTips: [
+      "If a virtual office is used, prompt the agent to confirm state acceptance.",
+    ],
+  },
+  fein: {
+    title: "Federal EIN",
+    description: "Employer identification number assigned by the IRS.",
+    examples: ["92-8741032"],
+    aiTips: [
+      "Mask the middle digits when sharing via chat to reduce exposure.",
+    ],
+  },
+  dbaName: {
+    title: "Doing business as (DBA)",
+    description: "Trade name under which the company operates.",
+    examples: ["Silver State Auto Brokers"],
+    aiTips: [
+      "Ensure the DBA spelling matches the county filing to avoid rejection.",
+    ],
+  },
+  entityType: {
+    title: "Entity type",
+    description: "Classification of the business (LLC, Corporation, Partnership, etc.).",
+    examples: ["California LLC", "S-Corporation"],
+    aiTips: [
+      "Map entity types to the internal workflow IDs for downstream automations.",
+    ],
+  },
+  articlesReference: {
+    title: "Formation document reference",
+    description: "Document number or filing ID from the Articles of Organization/Incorporation.",
+    examples: ["2024-LLC-00981"],
+    aiTips: [
+      "Double-check the filing year aligns with the application timeline.",
+    ],
+  },
+  registeredAgent: {
+    title: "Registered agent",
+    description: "Name and address of the agent for service of process.",
+    examples: ["Harbor Compliance, 1201 F St NW, Washington, DC 20004"],
+    aiTips: [
+      "Highlight when the agent is the same as the owner to confirm acceptance rules.",
+    ],
+  },
+  contactEmail: {
+    title: "Contact email",
+    description: "Primary email for business correspondence.",
+    examples: ["hello@harborcitylogistics.com"],
+    aiTips: [
+      "Validate format and flag consumer email domains if the client expects a branded address.",
+    ],
+  },
+  contactPhone: {
+    title: "Contact phone",
+    description: "Main phone number for the business or vehicle owner.",
+    examples: ["(562) 555-0193"],
+    aiTips: [
+      "Normalize to E.164 format before syncing to telephony systems.",
+    ],
+  },
+  formationDate: {
+    title: "Formation date",
+    description: "Official date the business entity was created.",
+    examples: ["04/05/2024"],
+    aiTips: [
+      "Surface compliance reminders if the formation date is less than 30 days old.",
+    ],
+  },
+  operatingAgreement: {
+    title: "Operating agreement reference",
+    description:
+      "Key clause identifiers or signature pages from the operating agreement or bylaws.",
+    aiTips: [
+      "Flag missing member signatures to ensure the agreement is fully executed.",
+    ],
+  },
+} satisfies Record<string, FieldHint>;
+
+export type FieldHintKey = keyof typeof fieldHints;
+
+export function resolveFieldHints(keys: FieldHintKey[]) {
+  return keys
+    .map((key) => ({ key, hint: fieldHints[key] }))
+    .filter((entry): entry is { key: FieldHintKey; hint: FieldHint } => Boolean(entry.hint));
+}


### PR DESCRIPTION
## Summary
- add SmartChecklist, Question, and DocumentHelper components for reusable flow UIs
- implement PDF and image extraction helpers alongside shared field hint metadata
- create registration renewal, title transfer, and new business flow pages powered by the new components

## Testing
- not run (project setup not available in workspace)


------
https://chatgpt.com/codex/tasks/task_b_68d6ab7b903c832193980207c1509f5a