### PR TITLE
feat: add audit compliance layer

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,21 @@
+// SQLite dev store for audit logs. Can migrate to Postgres later.
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model AuditLog {
+  id           String   @id @default(cuid())
+  createdAt    DateTime @default(now())
+  route        String
+  userContext  Json
+  messages     Json     // redacted messages
+  response     String   // trimmed text
+  tools        Json     // tools invoked & params
+  piiRedactions Int     // count of redactions applied
+  confidence   Float    // model/app confidence (0..1)
+}

--- a/src/app/accessibility/page.tsx
+++ b/src/app/accessibility/page.tsx
@@ -1,0 +1,124 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Accessibility & Inclusive Design | TCSLC AI",
+  description:
+    "How TCSLC builds AI-native experiences that are perceivable, operable, understandable, and robust for every learner and patient.",
+};
+
+const STANDARDS = [
+  {
+    title: "Perceivable",
+    detail:
+      "Color contrast meets WCAG 2.2 AA targets, motion can be reduced, and transcripts or captions are provided for every multimedia surface.",
+  },
+  {
+    title: "Operable",
+    detail:
+      "Every workflow is fully keyboard navigable with clear focus states, logical tab order, and bypass links for repetitive content.",
+  },
+  {
+    title: "Understandable",
+    detail:
+      "We author plain-language summaries alongside AI explanations and keep terminology consistent across patient, clinician, and admin views.",
+  },
+  {
+    title: "Robust",
+    detail:
+      "Interfaces are tested with assistive technologies including screen readers, voice control, and switch devices before shipping.",
+  },
+];
+
+const SUPPORT_CHANNELS = [
+  {
+    heading: "Accessibility desk",
+    body: "Email access@tcslc.com for prioritized assistance, VPAT requests, or to request accessible training materials.",
+  },
+  {
+    heading: "24/7 hotline",
+    body: "Call 1-800-555-8275 to report issues impacting care delivery. We connect you with an on-call specialist within 15 minutes.",
+  },
+  {
+    heading: "Feedback loop",
+    body: "Use the in-product \"Report an issue\" shortcut or submit a GitHub issue in our public accessibility tracker.",
+  },
+];
+
+export default function AccessibilityPage() {
+  return (
+    <div className="relative isolate mx-auto max-w-6xl space-y-16 px-6 py-16 lg:py-24">
+      <header className="space-y-4 text-slate-200">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-400">Accessibility</p>
+        <h1 className="text-4xl font-semibold text-white sm:text-5xl">Inclusive, assistive-first experiences</h1>
+        <p className="text-base text-slate-300">
+          Equity is a product requirement. We invest in inclusive research, test with diverse learners and clinicians, and
+          build remediation hooks directly into our AI copilots so accessibility never slips to a backlog.
+        </p>
+      </header>
+
+      <section className="grid gap-8 rounded-3xl border border-white/10 bg-slate-950/60 p-8 shadow-lg shadow-black/30 lg:grid-cols-[1.2fr,1fr]">
+        <div className="space-y-6 text-slate-200">
+          <h2 className="text-lg font-semibold text-white">WCAG 2.2 AA as a baseline</h2>
+          <p className="text-sm text-slate-300">
+            Our cross-functional accessibility guild runs automated and manual audits across every release train. These four
+            pillars guide design, content, and engineering decisions across the TCSLC platform.
+          </p>
+          <dl className="grid gap-6 sm:grid-cols-2">
+            {STANDARDS.map((standard) => (
+              <div key={standard.title} className="rounded-2xl border border-white/5 bg-white/5 p-5">
+                <dt className="text-base font-semibold text-white">{standard.title}</dt>
+                <dd className="mt-2 text-sm text-slate-300">{standard.detail}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+        <div className="space-y-4 rounded-2xl border border-white/5 bg-slate-950/80 p-6 text-sm text-slate-300">
+          <h3 className="text-base font-semibold text-white">Assistive technology coverage</h3>
+          <p>
+            We certify support for JAWS, NVDA, VoiceOver, TalkBack, Dragon NaturallySpeaking, and switch control interfaces.
+            New feature work only ships after passing our assistive compatibility matrix.
+          </p>
+          <p>
+            Need documentation in Braille-ready or large-print formats? Let us know and we will provide accessible exports
+            within two business days.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid gap-8 lg:grid-cols-2">
+        <div className="space-y-4 rounded-3xl border border-white/10 bg-slate-950/60 p-8 text-slate-200">
+          <h2 className="text-lg font-semibold text-white">Inclusive AI operations</h2>
+          <ul className="space-y-3 text-sm text-slate-300">
+            <li>
+              <span className="font-semibold text-white">Diverse evaluators:</span> We compensate clinicians and learners with
+              disabilities to evaluate prompts, transcripts, and UI updates.
+            </li>
+            <li>
+              <span className="font-semibold text-white">Bias monitoring:</span> Accessibility-specific test suites flag
+              regressions in alternative text quality, caption coverage, and language complexity.
+            </li>
+            <li>
+              <span className="font-semibold text-white">Continuous education:</span> Every engineer participates in quarterly
+              accessibility labs covering semantics, screen reader etiquette, and inclusive writing.
+            </li>
+          </ul>
+        </div>
+        <div className="space-y-4 rounded-3xl border border-white/10 bg-slate-950/60 p-8 text-slate-200">
+          <h2 className="text-lg font-semibold text-white">We're here to help</h2>
+          <p className="text-sm text-slate-300">
+            Accessibility is a shared practice. Our support team and accessibility guild collaborate to resolve issues fast
+            and learn from every interaction.
+          </p>
+          <ul className="space-y-3 text-sm text-slate-300">
+            {SUPPORT_CHANNELS.map((channel) => (
+              <li key={channel.heading} className="rounded-2xl border border-white/5 bg-white/5 p-5">
+                <h3 className="text-base font-semibold text-white">{channel.heading}</h3>
+                <p className="mt-1">{channel.body}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,135 @@
+import type { Metadata } from "next";
+
+import WhyYouSeeThis from "../../components/assistant/WhyYouSeeThis";
+
+export const metadata: Metadata = {
+  title: "Privacy & Responsible AI | TCSLC AI",
+  description:
+    "How TCSLC protects patient trust through encryption, minimization, and transparent governance across our AI-native platform.",
+};
+
+const PRINCIPLES = [
+  {
+    title: "Use minimization by design",
+    description:
+      "We only collect the data we need to deliver care-quality experiences, retain it for the shortest window possible, and give you controls to purge or export on demand.",
+  },
+  {
+    title: "Security that matches clinical stakes",
+    description:
+      "Every interaction is encrypted in transit and at rest, scoped through role-based access, and monitored for anomalous behavior with automated containment.",
+  },
+  {
+    title: "Transparent model stewardship",
+    description:
+      "We document training sources, evaluation datasets, and deployment guardrails so you can explain outcomes to patients, regulators, and partners.",
+  },
+];
+
+const DATA_FLOW = [
+  {
+    name: "Source systems",
+    details:
+      "EHR, LMS, and scheduling systems stream into an isolated ingress where PHI is tokenized before any AI processing begins.",
+  },
+  {
+    name: "AI processing",
+    details:
+      "Models operate on the tokenized layer with differential privacy, and only return the minimum structured insight needed for the workflow.",
+  },
+  {
+    name: "Analytics lake",
+    details:
+      "Aggregated telemetry lands in a HIPAA-aligned analytics lake with lineage so you can audit every downstream dashboard.",
+  },
+];
+
+export default function PrivacyPage() {
+  return (
+    <div className="relative isolate mx-auto flex max-w-6xl flex-col gap-16 px-6 py-16 lg:flex-row lg:py-24">
+      <div className="mx-auto w-full max-w-3xl space-y-12 text-slate-200">
+        <header className="space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-400">Privacy</p>
+          <h1 className="text-4xl font-semibold text-white sm:text-5xl">Patient-trusted data stewardship</h1>
+          <p className="text-base text-slate-300">
+            Privacy is not a policy PDF—it is a living assurance program embedded into every surface of the TCSLC
+            platform. From data ingress to model outputs, we engineer for least privilege, observability, and clear human
+            accountability.
+          </p>
+        </header>
+
+        <section className="space-y-6 rounded-3xl border border-white/10 bg-slate-950/60 p-8 shadow-lg shadow-black/30">
+          <h2 className="text-lg font-semibold text-white">Our operating principles</h2>
+          <p className="text-sm text-slate-300">
+            These are the commitments we sign in our BAAs and revisit during every architecture review. They apply to the
+            core platform, our AI copilots, and any integrations managed by TCSLC.
+          </p>
+          <ul className="grid gap-6 sm:grid-cols-2">
+            {PRINCIPLES.map((principle) => (
+              <li key={principle.title} className="rounded-2xl border border-white/5 bg-white/5 p-5">
+                <h3 className="text-base font-semibold text-white">{principle.title}</h3>
+                <p className="mt-2 text-sm text-slate-300">{principle.description}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="space-y-6">
+          <div className="rounded-3xl border border-white/10 bg-slate-950/60 p-8">
+            <h2 className="text-lg font-semibold text-white">How data flows through the platform</h2>
+            <p className="text-sm text-slate-300">
+              We provide a documented, reviewable path for data so you can map it to your own compliance frameworks. Each
+              stage includes automated checkpoints and human sign-off.
+            </p>
+            <ol className="mt-6 space-y-4">
+              {DATA_FLOW.map((stage, index) => (
+                <li key={stage.name} className="flex gap-4">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-500/10 text-sm font-semibold text-sky-300">
+                    {String(index + 1).padStart(2, "0")}
+                  </div>
+                  <div className="space-y-1">
+                    <h3 className="text-base font-semibold text-white">{stage.name}</h3>
+                    <p className="text-sm text-slate-300">{stage.details}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <div className="space-y-4 rounded-3xl border border-white/10 bg-slate-950/60 p-8">
+            <h2 className="text-lg font-semibold text-white">Your controls</h2>
+            <ul className="space-y-3 text-sm text-slate-300">
+              <li>
+                <span className="font-semibold text-white">Data portability:</span> Export structured transcripts, audit
+                trails, and annotations to your warehouse or SIEM.
+              </li>
+              <li>
+                <span className="font-semibold text-white">Retention policies:</span> Configure rolling deletion windows or
+                legal hold for specific practice groups.
+              </li>
+              <li>
+                <span className="font-semibold text-white">Subject rights:</span> Automated workflows for access, correction,
+                and deletion requests ensure we respond within SLA.
+              </li>
+            </ul>
+          </div>
+        </section>
+      </div>
+
+      <aside className="w-full max-w-md shrink-0 space-y-8">
+        <WhyYouSeeThis />
+        <div className="space-y-3 rounded-2xl border border-white/10 bg-slate-950/60 p-6 text-sm text-slate-300">
+          <h2 className="text-base font-semibold text-white">Regulatory alignment</h2>
+          <p>
+            TCSLC AI is built to exceed HIPAA, FERPA, and state privacy law requirements. We map our controls to NIST 800-53
+            and HITRUST, and our team participates in annual third-party audits.
+          </p>
+          <p>
+            Need custom documentation or to schedule a data protection impact assessment? Contact compliance@tcslc.com and we
+            will respond within one business day.
+          </p>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/components/assistant/WhyYouSeeThis.tsx
+++ b/src/components/assistant/WhyYouSeeThis.tsx
@@ -1,0 +1,71 @@
+import { Database, Eye, ShieldCheck, Workflow } from "lucide-react";
+
+const ITEMS = [
+  {
+    icon: ShieldCheck,
+    title: "Privacy-preserving guardrails",
+    description:
+      "We automatically redact emails, phone numbers, payment details, and other identifiers before any data leaves your session.",
+  },
+  {
+    icon: Workflow,
+    title: "Traceable actions",
+    description:
+      "Every tool invocation and human override is captured in an immutable audit log so you can reconstruct decisions end-to-end.",
+  },
+  {
+    icon: Eye,
+    title: "Accountable transparency",
+    description:
+      "You can always inspect why a recommendation was made, the model confidence, and any safeguards that were triggered.",
+  },
+  {
+    icon: Database,
+    title: "Data residency controls",
+    description:
+      "Logs stay in-region and can be routed to your preferred lakehouse or SIEM with retention policies you control.",
+  },
+];
+
+export function WhyYouSeeThis() {
+  return (
+    <section className="space-y-6 rounded-2xl border border-white/10 bg-slate-950/80 p-6 text-slate-200 shadow-xl shadow-slate-900/40">
+      <header className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+          Why you're seeing this
+        </p>
+        <h2 className="text-xl font-semibold text-white">A transparent AI co-pilot</h2>
+        <p className="text-sm text-slate-300">
+          Every response includes the compliance, privacy, and quality signals that our assurance layer evaluated so
+          your team can trust what ships to patients and partners.
+        </p>
+      </header>
+
+      <dl className="grid gap-4 sm:grid-cols-2">
+        {ITEMS.map((item) => (
+          <div
+            key={item.title}
+            className="group flex gap-4 rounded-xl border border-white/5 bg-white/5 p-4 transition hover:border-sky-400/60 hover:bg-sky-400/10"
+          >
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-500/10 text-sky-300 transition group-hover:bg-sky-500/20 group-hover:text-sky-200">
+              <item.icon className="h-5 w-5" aria-hidden="true" />
+            </div>
+            <div className="space-y-1">
+              <dt className="text-sm font-semibold text-white">{item.title}</dt>
+              <dd className="text-sm text-slate-300">{item.description}</dd>
+            </div>
+          </div>
+        ))}
+      </dl>
+
+      <footer className="rounded-xl border border-white/5 bg-slate-900/80 p-4 text-xs text-slate-400">
+        <p>
+          Need to export an audit package or configure retention? Reach out to your TCSLC compliance manager and we'll
+          wire this feed into your existing governance workflows.
+        </p>
+      </footer>
+    </section>
+  );
+}
+
+export default WhyYouSeeThis;

--- a/src/lib/ai/confidence.ts
+++ b/src/lib/ai/confidence.ts
@@ -1,0 +1,59 @@
+export interface ConfidenceSignal {
+  source: string;
+  score: number;
+  weight?: number;
+  rationale?: string;
+}
+
+export interface NormalizedConfidenceSignal {
+  source: string;
+  score: number;
+  weight: number;
+  rationale?: string;
+}
+
+export interface ConfidenceSummary {
+  score: number;
+  rawScore: number;
+  totalWeight: number;
+  signals: NormalizedConfidenceSignal[];
+}
+
+const clamp = (value: number, min = 0, max = 1) => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+
+  return Math.min(Math.max(value, min), max);
+};
+
+export function normalizeSignals(signals: ConfidenceSignal[]): NormalizedConfidenceSignal[] {
+  return signals
+    .filter((signal) => Number.isFinite(signal.score))
+    .map((signal) => ({
+      source: signal.source,
+      score: clamp(signal.score),
+      weight: signal.weight && signal.weight > 0 ? signal.weight : 1,
+      rationale: signal.rationale,
+    }));
+}
+
+export function calculateConfidence(
+  signals: ConfidenceSignal[],
+  fallbackScore = 0.6,
+): ConfidenceSummary {
+  const normalized = normalizeSignals(signals);
+  const totalWeight = normalized.reduce((total, signal) => total + signal.weight, 0);
+
+  const rawScore =
+    totalWeight > 0
+      ? normalized.reduce((total, signal) => total + signal.score * signal.weight, 0) / totalWeight
+      : clamp(fallbackScore);
+
+  return {
+    score: clamp(rawScore),
+    rawScore,
+    totalWeight,
+    signals: normalized,
+  };
+}

--- a/src/lib/audit/db.ts
+++ b/src/lib/audit/db.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from "@prisma/client";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prismaAudit: PrismaClient | undefined;
+}
+
+const prismaClientSingleton = () =>
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"],
+  });
+
+export type AuditDatabaseClient = PrismaClient;
+
+const client = globalThis.prismaAudit ?? prismaClientSingleton();
+
+if (process.env.NODE_ENV !== "production") {
+  globalThis.prismaAudit = client;
+}
+
+export const auditDb = client;

--- a/src/lib/audit/logger.ts
+++ b/src/lib/audit/logger.ts
@@ -1,0 +1,90 @@
+import type { AuditLog } from "@prisma/client";
+
+import { calculateConfidence, type ConfidenceSignal, type ConfidenceSummary } from "../ai/confidence";
+
+import { auditDb } from "./db";
+import { redactConversation, type AuditMessage } from "./redact";
+
+export interface ToolInvocation {
+  name: string;
+  arguments?: unknown;
+  result?: unknown;
+  durationMs?: number;
+  success?: boolean;
+}
+
+export interface AuditLogInput {
+  route: string;
+  userContext?: Record<string, unknown>;
+  messages: AuditMessage[];
+  response: string;
+  tools?: ToolInvocation[];
+  confidence?: number;
+  confidenceSignals?: ConfidenceSignal[];
+  fallbackConfidence?: number;
+}
+
+export interface AuditLogResult {
+  record: AuditLog;
+  redactions: number;
+  confidenceSummary: ConfidenceSummary;
+}
+
+const clampConfidence = (value: number) => {
+  if (!Number.isFinite(value)) {
+    return 0.6;
+  }
+
+  return Math.min(Math.max(value, 0), 1);
+};
+
+const MAX_RESPONSE_LENGTH = 4000;
+
+const trimResponse = (response: string) => {
+  if (response.length <= MAX_RESPONSE_LENGTH) {
+    return response;
+  }
+
+  return `${response.slice(0, MAX_RESPONSE_LENGTH - 1)}…`;
+};
+
+export async function writeAuditLog(input: AuditLogInput): Promise<AuditLogResult> {
+  const { messages: redactedMessages, totalRedactions } = redactConversation(input.messages);
+  const trimmedResponse = trimResponse(input.response);
+  const fallbackConfidence = typeof input.fallbackConfidence === "number" ? input.fallbackConfidence : 0.6;
+  const summaryFromSignals = calculateConfidence(input.confidenceSignals ?? [], fallbackConfidence);
+  const resolvedConfidence =
+    typeof input.confidence === "number" ? clampConfidence(input.confidence) : summaryFromSignals.score;
+
+  const confidenceSummary: ConfidenceSummary =
+    typeof input.confidence === "number"
+      ? {
+          ...summaryFromSignals,
+          score: resolvedConfidence,
+          rawScore: input.confidence,
+        }
+      : summaryFromSignals;
+
+  try {
+    const record = await auditDb.auditLog.create({
+      data: {
+        route: input.route,
+        userContext: input.userContext ?? {},
+        messages: redactedMessages,
+        response: trimmedResponse,
+        tools: input.tools ?? [],
+        piiRedactions: totalRedactions,
+        confidence: resolvedConfidence,
+      },
+    });
+
+    return {
+      record,
+      redactions: totalRedactions,
+      confidenceSummary,
+    };
+  } catch (error) {
+    console.error("Failed to write audit log", error);
+    throw error;
+  }
+}

--- a/src/lib/audit/redact.ts
+++ b/src/lib/audit/redact.ts
@@ -1,0 +1,174 @@
+export type PrimitiveMessageContent = string;
+export type RichMessageSegment = {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+};
+
+export type MessageContent = PrimitiveMessageContent | RichMessageSegment[];
+
+export interface AuditMessage {
+  role: string;
+  content: MessageContent;
+  name?: string;
+  id?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RedactionBreakdown {
+  [pattern: string]: number;
+}
+
+export interface RedactTextResult {
+  text: string;
+  redactions: number;
+  breakdown: RedactionBreakdown;
+}
+
+export interface RedactedConversation {
+  messages: AuditMessage[];
+  totalRedactions: number;
+  breakdown: RedactionBreakdown;
+}
+
+type RedactionRule = {
+  name: string;
+  regex: RegExp;
+  placeholder: string;
+};
+
+const REDACTION_RULES: RedactionRule[] = [
+  {
+    name: "email",
+    regex: /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi,
+    placeholder: "[redacted-email]",
+  },
+  {
+    name: "phone",
+    regex: /(?:(?:\+?\d{1,3}[\s.-]?)?(?:\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4})/g,
+    placeholder: "[redacted-phone]",
+  },
+  {
+    name: "ssn",
+    regex: /\b\d{3}-\d{2}-\d{4}\b/g,
+    placeholder: "[redacted-ssn]",
+  },
+  {
+    name: "creditCard",
+    regex: /\b(?:\d[ -]*?){13,16}\b/g,
+    placeholder: "[redacted-card]",
+  },
+  {
+    name: "apiKey",
+    regex: /(sk|pk|tok|ghp)_[A-Za-z0-9]{16,}/g,
+    placeholder: "[redacted-secret]",
+  },
+  {
+    name: "url",
+    regex: /https?:\/\/[^\s]+/gi,
+    placeholder: "[redacted-url]",
+  },
+];
+
+const clamp = (value: number) => (Number.isFinite(value) ? value : 0);
+
+export function redactText(input: string): RedactTextResult {
+  let text = input;
+  const breakdown: RedactionBreakdown = {};
+
+  for (const rule of REDACTION_RULES) {
+    const matches = text.match(rule.regex);
+    if (!matches) {
+      continue;
+    }
+
+    breakdown[rule.name] = (breakdown[rule.name] ?? 0) + matches.length;
+    text = text.replace(rule.regex, rule.placeholder);
+  }
+
+  const redactions = Object.values(breakdown).reduce((total, value) => total + clamp(value), 0);
+
+  return {
+    text,
+    redactions,
+    breakdown,
+  };
+}
+
+function mergeBreakdowns(target: RedactionBreakdown, addition: RedactionBreakdown) {
+  for (const [key, value] of Object.entries(addition)) {
+    target[key] = (target[key] ?? 0) + clamp(value);
+  }
+}
+
+function redactRichContent(segments: RichMessageSegment[]): {
+  segments: RichMessageSegment[];
+  redactions: number;
+  breakdown: RedactionBreakdown;
+} {
+  const sanitizedSegments: RichMessageSegment[] = [];
+  const breakdown: RedactionBreakdown = {};
+  let redactions = 0;
+
+  for (const segment of segments) {
+    if (typeof segment.text === "string") {
+      const { text, redactions: segmentRedactions, breakdown: segmentBreakdown } = redactText(segment.text);
+      sanitizedSegments.push({ ...segment, text });
+      mergeBreakdowns(breakdown, segmentBreakdown);
+      redactions += segmentRedactions;
+    } else {
+      sanitizedSegments.push({ ...segment });
+    }
+  }
+
+  return { segments: sanitizedSegments, redactions, breakdown };
+}
+
+function sanitizeMessage(message: AuditMessage): {
+  message: AuditMessage;
+  redactions: number;
+  breakdown: RedactionBreakdown;
+} {
+  if (typeof message.content === "string") {
+    const { text, redactions, breakdown } = redactText(message.content);
+    return {
+      message: { ...message, content: text },
+      redactions,
+      breakdown,
+    };
+  }
+
+  if (Array.isArray(message.content)) {
+    const { segments, redactions, breakdown } = redactRichContent(message.content);
+    return {
+      message: { ...message, content: segments },
+      redactions,
+      breakdown,
+    };
+  }
+
+  return {
+    message: { ...message },
+    redactions: 0,
+    breakdown: {},
+  };
+}
+
+export function redactConversation(messages: AuditMessage[]): RedactedConversation {
+  const sanitizedMessages: AuditMessage[] = [];
+  const breakdown: RedactionBreakdown = {};
+  let totalRedactions = 0;
+
+  for (const message of messages) {
+    const { message: sanitizedMessage, redactions, breakdown: messageBreakdown } = sanitizeMessage(message);
+    sanitizedMessages.push(sanitizedMessage);
+    mergeBreakdowns(breakdown, messageBreakdown);
+    totalRedactions += redactions;
+  }
+
+  return {
+    messages: sanitizedMessages,
+    totalRedactions,
+    breakdown,
+  };
+}


### PR DESCRIPTION
## Summary
- add prisma schema and audit logging utilities with redaction and confidence helpers
- introduce transparency-focused WhyYouSeeThis assistant component
- refresh privacy and accessibility pages with updated compliance and accessibility copy

## Testing
- pnpm dev *(fails: No package.json present in repo)*

------
https://chatgpt.com/codex/tasks/task_b_68d6ad01dbd483218fa65e07d415e9d1