### PR TITLE
Add locations page with queue and hours utilities

### DIFF
--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+
+import { LocationCard } from "@/components/locations/LocationCard";
+import { LOCATIONS } from "@/lib/locations.data";
+
+export const metadata: Metadata = {
+  title: "Locations",
+  description:
+    "Find office locations, services, operating hours, and queue information for the St. Lucie County Tax Collector.",
+  alternates: {
+    canonical: "/locations"
+  }
+};
+
+export default function LocationsPage() {
+  return (
+    <main className="min-h-screen bg-slate-50 py-16 text-slate-900 dark:bg-slate-950 dark:text-white">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-12 px-6 md:px-8">
+        <section className="space-y-4 text-center md:text-left">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-600 dark:text-emerald-400">
+            Visit us in person
+          </p>
+          <h1 className="text-3xl font-bold tracking-tight text-slate-900 dark:text-white sm:text-4xl">
+            Locations, hours, and live queues
+          </h1>
+          <p className="text-base text-slate-600 dark:text-slate-300 md:text-lg">
+            Explore each service center to confirm operating hours, plan your visit with live queue links, and find
+            tailored services by location.
+          </p>
+        </section>
+
+        <section className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+          {LOCATIONS.map((location) => (
+            <LocationCard key={location.id} location={location} />
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/locations/LocationCard.tsx
+++ b/src/components/locations/LocationCard.tsx
@@ -1,0 +1,116 @@
+import Link from "next/link";
+import { Clock, ExternalLink, ListChecks, MapPin, Phone } from "lucide-react";
+
+import type { Location } from "@/lib/locations.data";
+import { getOrderedHours, getTodayHours, isOpenNow } from "@/lib/hours";
+import { getQueueLink } from "@/lib/queues";
+
+const serviceBadgeClasses =
+  "rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700 transition-colors hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700";
+
+export type LocationCardProps = {
+  location: Location;
+};
+
+export function LocationCard({ location }: LocationCardProps) {
+  const { name, address, phone, hours, services, mapUrl, queueUrl } = location;
+
+  const todayHours = getTodayHours(hours);
+  const openNow = isOpenNow(hours);
+  const queueLink = getQueueLink(queueUrl);
+  const orderedHours = getOrderedHours(hours);
+
+  return (
+    <article className="group flex flex-col gap-6 rounded-2xl border border-slate-200/80 bg-white/80 p-6 shadow-sm ring-1 ring-transparent transition hover:border-slate-300 hover:shadow-md hover:ring-slate-200 dark:border-slate-800/80 dark:bg-slate-900/70 dark:hover:border-slate-700 dark:hover:ring-slate-800">
+      <header className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{name}</h3>
+          <span
+            className={`flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${openNow ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200" : "bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200"}`}
+          >
+            <Clock className="h-4 w-4" />
+            {openNow ? "Open now" : "Closed"}
+          </span>
+        </div>
+        <p className="text-sm text-slate-600 dark:text-slate-300">{address}</p>
+        {todayHours ? (
+          <p className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+            <Clock className="h-4 w-4" />
+            Today: {todayHours}
+          </p>
+        ) : null}
+      </header>
+
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex flex-1 flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Services
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {services.map((service) => (
+                <span key={service} className={serviceBadgeClasses}>
+                  <ListChecks className="mr-1 inline-block h-3 w-3" />
+                  {service}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Weekly hours
+            </h4>
+            <dl className="grid grid-cols-1 gap-y-1 text-sm text-slate-600 dark:text-slate-300 sm:grid-cols-2">
+              {orderedHours.map(({ day, value }) => (
+                <div key={day} className="flex items-center justify-between gap-4 rounded-lg bg-slate-50 px-3 py-2 dark:bg-slate-800/60">
+                  <dt className="font-medium text-slate-700 dark:text-slate-200">{day}</dt>
+                  <dd className="text-right text-slate-600 dark:text-slate-300">{value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </div>
+
+        <div className="flex w-full flex-col gap-3 md:w-56">
+          {phone ? (
+            <Link
+              href={`tel:${phone.replace(/[^\d]/g, "")}`}
+              className="flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:border-slate-600 dark:hover:bg-slate-800"
+            >
+              <Phone className="h-4 w-4" />
+              Call {phone}
+            </Link>
+          ) : null}
+          {mapUrl ? (
+            <Link
+              href={mapUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center gap-2 rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:bg-slate-700 dark:hover:bg-slate-600"
+            >
+              <MapPin className="h-4 w-4" />
+              Directions
+              <ExternalLink className="h-4 w-4" />
+            </Link>
+          ) : null}
+          {queueLink ? (
+            <Link
+              href={queueLink.href}
+              target={queueLink.target}
+              rel={queueLink.rel}
+              className="flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 py-3 text-sm font-semibold text-white shadow hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+            >
+              Join the queue
+              <ExternalLink className="h-4 w-4" />
+            </Link>
+          ) : (
+            <div className="flex items-center justify-center gap-2 rounded-xl border border-dashed border-slate-300 px-4 py-3 text-center text-xs font-medium uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400">
+              Walk-in service only
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/lib/hours.ts
+++ b/src/lib/hours.ts
@@ -1,0 +1,131 @@
+export const WEEK_DAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday"
+] as const;
+
+export type HoursRecord = Record<string, string>;
+
+type HoursRange = {
+  startMinutes: number;
+  endMinutes: number;
+};
+
+const CLOSED_KEYWORDS = ["closed", "appointment only"];
+
+const timeFormatter = new Intl.DateTimeFormat("en-US", {
+  hour: "numeric",
+  minute: "2-digit",
+  hour12: true
+});
+
+function normalizeRange(rawValue: string): string {
+  return rawValue.replace(/\u2013/g, "-");
+}
+
+function parseTimeString(value: string): number | null {
+  const trimmed = value.trim();
+  const match = trimmed.match(/^(\d{1,2})(?::(\d{2}))?\s*(AM|PM)$/i);
+
+  if (!match) {
+    return null;
+  }
+
+  const hours = Number.parseInt(match[1] ?? "0", 10);
+  const minutes = Number.parseInt(match[2] ?? "0", 10);
+  const period = match[3]?.toUpperCase();
+
+  if (Number.isNaN(hours) || Number.isNaN(minutes) || !period) {
+    return null;
+  }
+
+  const normalizedHours = hours % 12 + (period === "PM" ? 12 : 0);
+
+  return normalizedHours * 60 + minutes;
+}
+
+function parseHoursRange(value: string): HoursRange | null {
+  const normalized = normalizeRange(value);
+  const [start, end] = normalized.split("-");
+
+  if (!start || !end) {
+    return null;
+  }
+
+  const startMinutes = parseTimeString(start);
+  const endMinutes = parseTimeString(end);
+
+  if (startMinutes === null || endMinutes === null) {
+    return null;
+  }
+
+  return {
+    startMinutes,
+    endMinutes
+  };
+}
+
+function containsClosedKeyword(value: string): boolean {
+  const normalized = value.toLowerCase();
+  return CLOSED_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+export function getDayLabel(date: Date = new Date()): (typeof WEEK_DAYS)[number] {
+  return WEEK_DAYS[date.getDay()];
+}
+
+export function getTodayHours(
+  hours: HoursRecord,
+  date: Date = new Date()
+): string | null {
+  const day = getDayLabel(date);
+  const value = hours[day];
+
+  if (!value) {
+    return null;
+  }
+
+  return value;
+}
+
+export function isOpenNow(hours: HoursRecord, date: Date = new Date()): boolean {
+  const todayHours = getTodayHours(hours, date);
+
+  if (!todayHours || containsClosedKeyword(todayHours)) {
+    return false;
+  }
+
+  const range = parseHoursRange(todayHours);
+
+  if (!range) {
+    return false;
+  }
+
+  const minutesNow = date.getHours() * 60 + date.getMinutes();
+
+  return minutesNow >= range.startMinutes && minutesNow < range.endMinutes;
+}
+
+export function formatMinutesToDisplay(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  const date = new Date();
+  date.setHours(hours, minutes, 0, 0);
+
+  return timeFormatter.format(date);
+}
+
+export function getOrderedHours(hours: HoursRecord): Array<{
+  day: string;
+  value: string;
+}> {
+  return WEEK_DAYS.filter((day) => Boolean(hours[day])).map((day) => ({
+    day,
+    value: hours[day] as string
+  }));
+}

--- a/src/lib/locations.data.ts
+++ b/src/lib/locations.data.ts
@@ -1,0 +1,45 @@
+export type Location = {
+  id: string;
+  name: string;
+  address: string;
+  phone?: string;
+  hours: Record<string, string>;
+  services: string[];
+  mapUrl?: string;
+  queueUrl?: string;
+};
+
+export const LOCATIONS: Location[] = [
+  {
+    id: "ft-pierce",
+    name: "Main Office – Ft. Pierce",
+    address: "2300 Virginia Avenue, Ft. Pierce, FL 34982",
+    phone: "772-462-1650",
+    hours: {
+      Monday: "8:00 AM – 5:00 PM",
+      Tuesday: "8:00 AM – 5:00 PM",
+      Wednesday: "8:00 AM – 5:00 PM",
+      Thursday: "8:00 AM – 5:00 PM",
+      Friday: "8:00 AM – 5:00 PM"
+    },
+    services: ["Property Tax", "Driver License", "Motor Vehicle", "Business Tax"],
+    mapUrl: "https://maps.google.com/?q=2300+Virginia+Ave+Ft+Pierce+FL",
+    queueUrl: ""
+  },
+  {
+    id: "tradition",
+    name: "Tradition Office – Port St. Lucie",
+    address: "10264 SW Village Parkway, Port St. Lucie, FL 34987",
+    phone: "772-462-1650",
+    hours: {
+      Monday: "8:00 AM – 5:00 PM",
+      Tuesday: "8:00 AM – 5:00 PM",
+      Wednesday: "8:00 AM – 5:00 PM",
+      Thursday: "8:00 AM – 5:00 PM",
+      Friday: "8:00 AM – 5:00 PM"
+    },
+    services: ["Property Tax", "Driver License", "Motor Vehicle", "Hunting & Fishing"],
+    mapUrl: "https://maps.google.com/?q=10264+SW+Village+Pkwy+Port+St+Lucie+FL",
+    queueUrl: ""
+  }
+];

--- a/src/lib/queues.ts
+++ b/src/lib/queues.ts
@@ -1,0 +1,37 @@
+export type QueueLink = {
+  label: string;
+  href: string;
+  target: "_blank";
+  rel: string;
+};
+
+export const DEFAULT_QUEUE_LABEL = "Save your spot in line";
+
+function sanitizeUrl(value?: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function hasQueue(queueUrl?: string | null): boolean {
+  return Boolean(sanitizeUrl(queueUrl));
+}
+
+export function getQueueLink(queueUrl?: string | null): QueueLink | null {
+  const sanitized = sanitizeUrl(queueUrl);
+
+  if (!sanitized) {
+    return null;
+  }
+
+  return {
+    label: DEFAULT_QUEUE_LABEL,
+    href: sanitized,
+    target: "_blank",
+    rel: "noopener noreferrer"
+  };
+}


### PR DESCRIPTION
## Summary
- add shared location data along with supporting hours and queue helpers
- introduce a reusable LocationCard component for presenting branch details
- create the /locations page that assembles cards with descriptions and metadata

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6ae63f1b483219d21d93c020f4a9f